### PR TITLE
Fixed erroneous gcd behavior: gcd of zero and non-zero number should …

### DIFF
--- a/Sources/BigUInt GCD.swift
+++ b/Sources/BigUInt GCD.swift
@@ -17,7 +17,8 @@ extension BigUInt {
     @warn_unused_result
     public static func gcd(a: BigUInt, _ b: BigUInt) -> BigUInt {
         // This is Stein's algorithm: https://en.wikipedia.org/wiki/Binary_GCD_algorithm
-        if a.isZero || b.isZero { return BigUInt() }
+        if a.isZero { return b }
+        if b.isZero { return a }
 
         let az = a.trailingZeroes
         let bz = b.trailingZeroes

--- a/Tests/BigUIntTests.swift
+++ b/Tests/BigUIntTests.swift
@@ -685,8 +685,8 @@ class BigUIntTests: XCTestCase {
     }
 
     func testGCD() {
-        XCTAssertEqual(BigUInt.gcd(0, 2982891), 0)
-        XCTAssertEqual(BigUInt.gcd(2982891, 0), 0)
+        XCTAssertEqual(BigUInt.gcd(0, 2982891), 2982891)
+        XCTAssertEqual(BigUInt.gcd(2982891, 0), 2982891)
         XCTAssertEqual(BigUInt.gcd(0, 0), 0)
 
         XCTAssertEqual(BigUInt.gcd(4, 6), 2)


### PR DESCRIPTION
…return the non-zero number, not the zero. Discussed at https://en.wikipedia.org/wiki/Binary_GCD_algorithm among other sources.

Just a tiny change to gcd code and the 2 unit tests.

