### PR TITLE
Fix description of bitwise operation XOR

### DIFF
--- a/sources/BigUInt Bitwise Ops.swift
+++ b/sources/BigUInt Bitwise Ops.swift
@@ -73,7 +73,7 @@ extension BigUInt: BitwiseOperations {
         return result
     }
 
-    /// Calculate the bitwise OR of `a` and `b` and return the result.
+    /// Calculate the bitwise XOR of `a` and `b` and return the result.
     ///
     /// - Complexity: O(max(a.count, b.count))
     public static func ^ (a: BigUInt, b: BigUInt) -> BigUInt {


### PR DESCRIPTION
The documentation says ^ would calculate the bitwise OR (same as |), but actually it calculates XOR.