### PR TITLE
Add strict concurrency checks for Swift 6 support and fix concurrency warnings in tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM swift:6.1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+    "name": "Hylo LLVM",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "ubuntu",
+            "userUid": "automatic",
+            "userGid": "automatic",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined",
+        "--network=host"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "swiftlang.swift-vscode"
+            ]
+        }
+    },
+    "remoteUser": "ubuntu"
+}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: swift build --build-tests --enable-test-discovery
+      run: swift build --build-tests --enable-test-discovery -Xswiftc -strict-concurrency=complete
     - name: Test
-      run: swift test --enable-test-discovery --parallel
+      run: swift test --enable-test-discovery --parallel -Xswiftc -strict-concurrency=complete
       
   android:
     runs-on: macos-13

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,13 @@ let package = Package(
     ],
     products: [
         .library(name: "BigInt", targets: ["BigInt"])
-    ], 
+    ],
     targets: [
-        .target(name: "BigInt", path: "Sources"),
-        .testTarget(name: "BigIntTests", dependencies: ["BigInt"], path: "Tests")
+        .target(
+            name: "BigInt", path: "Sources",
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
+        .testTarget(
+            name: "BigIntTests", dependencies: ["BigInt"], path: "Tests",
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
     ]
 )

--- a/Tests/BigIntTests/Violet - Helpers/BitWidthTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/BitWidthTestCases.swift
@@ -62,7 +62,7 @@ internal enum BitWidthTestCases {
   // TLDR: bitWidth = power + 2
   internal static let positivePowersOf2Correction = 2
 
-  internal static var positivePowersOf2: [PowerTestCase] = {
+  internal static let positivePowersOf2: [PowerTestCase] = {
     var result = [PowerTestCase]()
 
     for (power, value) in allPositivePowersOf2(type: Int.self) {
@@ -86,7 +86,7 @@ internal enum BitWidthTestCases {
   // TLDR: bitWidth = power + 1
   internal static let negativePowersOf2Correction = 1
 
-  internal static var negativePowersOf2: [PowerTestCase] = {
+  internal static let negativePowersOf2: [PowerTestCase] = {
     var result = [PowerTestCase]()
 
     for (power, value) in allNegativePowersOf2(type: Int.self) {

--- a/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
@@ -66,7 +66,7 @@ internal enum WordsTestCases {
   internal typealias HeapTestCase = (words: [Word], expected: [UInt])
 
   // words: 1000 0000
-  internal static var heapPositive: [HeapTestCase] = {
+  internal static let heapPositive: [HeapTestCase] = {
     var result = [HeapTestCase]()
 
     for zeroWordCount in [1, 2] {
@@ -92,7 +92,7 @@ internal enum WordsTestCases {
   // words:      1000 0000
   // invert:     0111 1111
   // complement: 1000 0000
-  internal static var heapNegative_powerOf2: [HeapTestCase] = {
+  internal static let heapNegative_powerOf2: [HeapTestCase] = {
     var result = [HeapTestCase]()
 
     for zeroWordCount in [1, 2] {
@@ -121,7 +121,7 @@ internal enum WordsTestCases {
   // words:           1000 0001
   // invert:          0111 1110
   // complement: 1111 0111 1111
-  internal static var heapNegative_notPowerOf2: [HeapTestCase] = {
+  internal static let heapNegative_notPowerOf2: [HeapTestCase] = {
     var result = [HeapTestCase]()
 
     for zeroWordCount in [1, 2] {


### PR DESCRIPTION
This PR adds strict concurrency checks for the library while maintaining backwards compatibility with Swift tools 5.9.