### PR TITLE
Rename module to SwiftBigInt to fix module stability compilation

### DIFF
--- a/COMMIT_MESSAGE.txt
+++ b/COMMIT_MESSAGE.txt
@@ -1,0 +1,56 @@
+feat!: Rename module to SwiftBigInt to fix module stability compilation
+
+BREAKING CHANGE: Module name changed from BigInt to SwiftBigInt
+
+## Problem
+The module name "BigInt" conflicted with the struct name "public struct BigInt",
+causing Swift compiler errors when building with BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+(required for XCFramework distribution and module stability):
+
+```
+error: 'BigInt' is not a member type of struct 'BigInt.BigInt'
+```
+
+## Solution
+Renamed the module to "SwiftBigInt" following Swift community conventions
+(similar to SwiftNIO, SwiftLog, SwiftCrypto).
+
+## Changes
+- Package name: Remains "BigInt" (matches repository name)
+- Product name: BigInt → SwiftBigInt
+- Module name: BigInt → SwiftBigInt
+- Type names: UNCHANGED (BigInt and BigUInt structs remain the same)
+
+## Migration for Consumers
+Only import statements need to change:
+
+```swift
+// Before (v5.x):
+import BigInt
+
+// After (v6.0+):
+import SwiftBigInt
+
+// Type names unchanged:
+let x = BigInt(100)   // ✓ Still works
+let y = BigUInt(50)   // ✓ Still works
+```
+
+## Benefits
+- ✅ Fixes module stability compilation errors
+- ✅ Enables XCFramework distribution without compiler workarounds
+- ✅ Eliminates need for -no-verify-emitted-module-interface flag
+- ✅ Follows Swift community naming conventions
+- ✅ Minimal breaking changes (import statements only)
+
+## Files Modified
+- Package.swift: Updated module and product names
+- All test files (18 files): Updated imports
+- Demo playground files (5 files): Updated imports
+- README.md: Added migration guide
+- Documentation: Updated import examples
+
+## Version
+Requires major version bump: 5.4.0 → 6.0.0
+
+Fixes module interface verification bug when building with library evolution enabled.

--- a/COMMIT_MESSAGE_SHORT.txt
+++ b/COMMIT_MESSAGE_SHORT.txt
@@ -1,0 +1,16 @@
+feat!: Rename module to SwiftBigInt to fix module stability compilation
+
+BREAKING CHANGE: Module name changed from BigInt to SwiftBigInt
+
+Fixes Swift compiler error when building with BUILD_LIBRARY_FOR_DISTRIBUTION=YES:
+"'BigInt' is not a member type of struct 'BigInt.BigInt'"
+
+Changes:
+- Product/module name: BigInt → SwiftBigInt
+- Package name: Remains "BigInt" (repository name)
+- Type names: UNCHANGED (BigInt/BigUInt still work)
+
+Migration: Only import statements change from `import BigInt` to `import SwiftBigInt`
+
+Follows Swift naming conventions (SwiftNIO, SwiftLog, SwiftCrypto).
+Requires version bump to 6.0.0.

--- a/Demo.playground/Pages/Digits of Pi.xcplaygroundpage/Contents.swift
+++ b/Demo.playground/Pages/Digits of Pi.xcplaygroundpage/Contents.swift
@@ -1,5 +1,5 @@
 //: [Previous](@previous)
-import BigInt
+import SwiftBigInt
 //: ## Let's calculate the first thousand digits of π
 //:
 //: A fun application of BigInts is generating the digits of π.

--- a/Demo.playground/Pages/Factorials.xcplaygroundpage/Contents.swift
+++ b/Demo.playground/Pages/Factorials.xcplaygroundpage/Contents.swift
@@ -1,6 +1,6 @@
 //: [Previous](@previous)
 import Foundation
-import BigInt
+import SwiftBigInt
 //: The canonical way to demo big integers is with the factorial function. Here is a fancy definition for it:
 func fact(_ n: Int) -> BigInt {
     return (1 ... n).map { BigInt($0) }.reduce(BigInt(1), *)

--- a/Demo.playground/Pages/Generating Large Primes.xcplaygroundpage/Contents.swift
+++ b/Demo.playground/Pages/Generating Large Primes.xcplaygroundpage/Contents.swift
@@ -1,6 +1,6 @@
 //: [Previous](@previous)
 import Foundation
-import BigInt
+import SwiftBigInt
 //: # Generating Large Prime Numbers
 //:
 //: `BigUInt` has an `isPrime()` method that does a [Miller-Rabin Primality Test][mrpt]. Let's use

--- a/Demo.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/Demo.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -8,7 +8,7 @@
 //: (`BigInt` represents integers in base 2^64, storing digits in an `Array<UInt64>`, so the theoretical
 //: maximum value it can store is (2^64)^`Int.max` - 1.)
 import Foundation
-import BigInt
+import SwiftBigInt
 //: `BigInt` has several interesting initializers, but for now, the simplest way to create big integers is to use integer
 //: or string literals. The latter is useful when you want to create a number that's larger than `UIntMax.max`:
 let a: BigInt = 123

--- a/Demo.playground/Pages/The RSA algorithm.xcplaygroundpage/Contents.swift
+++ b/Demo.playground/Pages/The RSA algorithm.xcplaygroundpage/Contents.swift
@@ -1,6 +1,6 @@
 //: [Previous](@previous)
 import Foundation
-import BigInt
+import SwiftBigInt
 //: # RSA cryptography
 //:
 //: Another useful thing to have is a function that finds a random n-bit prime number:

--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,14 @@ let package = Package(
         .visionOS(.v1),
     ],
     products: [
-        .library(name: "BigInt", targets: ["BigInt"])
+        .library(name: "SwiftBigInt", targets: ["SwiftBigInt"])
     ],
     targets: [
         .target(
-            name: "BigInt", path: "Sources",
+            name: "SwiftBigInt", path: "Sources",
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
         .testTarget(
-            name: "BigIntTests", dependencies: ["BigInt"], path: "Tests",
+            name: "BigIntTests", dependencies: ["SwiftBigInt"], path: "Tests",
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ Setup instructions:
     .package(url: "https://github.com/attaswift/BigInt.git", from: "5.4.0")
     ```
 
+## <a name="migration">Migration from v5.x to v6.0</a>
+
+**Module Name Change**: Starting with v6.0, the module has been renamed from `BigInt` to `SwiftBigInt` to resolve Swift compiler conflicts when building with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` (required for XCFramework distribution and module stability).
+
+**The Issue**: The previous module name `BigInt` conflicted with the struct name `public struct BigInt`, causing compilation errors:
+```
+'BigInt' is not a member type of struct 'BigInt.BigInt'
+```
+
+**Migration Guide**: Simply update your import statements:
+```swift
+// Before (v5.x):
+import BigInt
+
+// After (v6.0+):
+import SwiftBigInt
+```
+
+**Important**: Type names remain unchanged. All code using `BigInt` and `BigUInt` continues to work as before:
+```swift
+import SwiftBigInt  // Only the import changes
+
+let x = BigInt(100)     // Type names stay the same ✓
+let y = BigUInt(50)     // Type names stay the same ✓
+```
+
+This change follows Swift community naming conventions (similar to `SwiftNIO`, `SwiftLog`, `SwiftCrypto`).
+
 ## <a name="notes">Implementation notes</a>
 
 [`BigUInt`][BigUInt] is a `MutableCollectionType` of its 64-bit digits, with the least significant
@@ -189,7 +217,7 @@ generic variant that was slower but more flexible.
 It is easy to use `BigInt` to calculate the factorial function for any integer:
 
 ```Swift
-import BigInt
+import SwiftBigInt
 
 func factorial(_ n: Int) -> BigInt {
     return (1 ... n).map { BigInt($0) }.reduce(BigInt(1), *)

--- a/SwiftBigInt.podspec
+++ b/SwiftBigInt.podspec
@@ -1,0 +1,43 @@
+Pod::Spec.new do |s|
+  s.name         = "SwiftBigInt"
+  s.version      = "6.0.1"
+  s.summary      = "Arbitrary-precision arithmetic in pure Swift"
+  s.description  = <<-DESC
+    This library provides arbitrary-precision integer arithmetic using pure Swift.
+    It defines two integer types: BigUInt for unsigned integers, and BigInt for 
+    signed integers. Both types have the full set of operations supported by Swift's 
+    standard integer types, plus more complicated arithmetic operations like division, 
+    exponentiation, modulo, GCD, square root, primality testing, and more.
+  DESC
+
+  s.homepage     = "https://github.com/jlalvarez18/BigInt"
+  s.license      = { :type => "MIT", :file => "LICENSE.md" }
+  s.author       = { "Károly Lőrentey" => "karoly@lorentey.hu" }
+  
+  s.swift_version = "5.9"
+  
+  # Platform support matching Package.swift
+  s.ios.deployment_target = "12.0"
+  s.osx.deployment_target = "10.13"
+  
+  s.source       = { :git => "https://github.com/jlalvarez18/BigInt.git", :tag => "v#{s.version}" }
+  s.source_files = "Sources/**/*.swift"
+  
+  s.module_name  = "SwiftBigInt"
+  s.requires_arc = true
+  
+  # Enable strict concurrency as specified in Package.swift
+  s.pod_target_xcconfig = {
+    'SWIFT_STRICT_CONCURRENCY' => 'complete'
+  }
+  
+  s.frameworks = "Foundation"
+  
+  # Test spec
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.pod_target_xcconfig = {
+      'SWIFT_STRICT_CONCURRENCY' => 'complete'
+    }
+  end
+end

--- a/Tests/BigIntTests/BigIntTests.swift
+++ b/Tests/BigIntTests/BigIntTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 import Foundation
 
 class BigIntTests: XCTestCase {

--- a/Tests/BigIntTests/BigUIntTests.swift
+++ b/Tests/BigIntTests/BigUIntTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import Foundation
-@testable import BigInt
+@testable import SwiftBigInt
 
 extension BigUInt.Kind: Equatable {
     public static func ==(left: BigUInt.Kind, right: BigUInt.Kind) -> Bool {

--- a/Tests/BigIntTests/ProfileTests.swift
+++ b/Tests/BigIntTests/ProfileTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import BigInt
+import SwiftBigInt
 
 #if Profile
 

--- a/Tests/BigIntTests/Tools.swift
+++ b/Tests/BigIntTests/Tools.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Károly Lőrentey. All rights reserved.
 //
 
-import BigInt
+import SwiftBigInt
 
 @inline(never)
 func noop<T>(_ value: T) {

--- a/Tests/BigIntTests/Violet - Helpers/BitWidthTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/BitWidthTestCases.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-@testable import BigInt
+@testable import SwiftBigInt
 
 internal enum BitWidthTestCases {
 

--- a/Tests/BigIntTests/Violet - Helpers/GenerateValues.swift
+++ b/Tests/BigIntTests/Violet - Helpers/GenerateValues.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-@testable import BigInt
+@testable import SwiftBigInt
 
 // MARK: - Int
 

--- a/Tests/BigIntTests/Violet - Helpers/StringTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/StringTestCases.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-@testable import BigInt
+@testable import SwiftBigInt
 
 // swiftlint:disable number_separator
 // swiftlint:disable line_length

--- a/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 // MARK: - Asserts
 

--- a/Tests/BigIntTests/Violet - Property testing/ApplyA_ApplyB_Equals_ApplyAB.swift
+++ b/Tests/BigIntTests/Violet - Property testing/ApplyA_ApplyB_Equals_ApplyAB.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 // swiftlint:disable type_name
 

--- a/Tests/BigIntTests/Violet - Property testing/ApplyA_UndoA.swift
+++ b/Tests/BigIntTests/Violet - Property testing/ApplyA_UndoA.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 // swiftlint:disable type_name
 

--- a/Tests/BigIntTests/Violet/BigIntCOWTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntCOWTests.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 // swiftlint:disable file_length
 

--- a/Tests/BigIntTests/Violet/BigIntHashTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntHashTests.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 // Well… actually… hash and equatable
 class BigIntHashTests: XCTestCase {

--- a/Tests/BigIntTests/Violet/BigIntIntegerInitTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntIntegerInitTests.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 private typealias Word = BigInt.Word
 

--- a/Tests/BigIntTests/Violet/BigIntPowerTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntPowerTests.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 class BigIntPowerTests: XCTestCase {
 

--- a/Tests/BigIntTests/Violet/BigIntPropertyTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntPropertyTests.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 private typealias Word = BigInt.Word
 

--- a/Tests/BigIntTests/Violet/BigIntStringInitTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntStringInitTests.swift
@@ -2,7 +2,7 @@
 // https://github.com/LiarPrincess/Violet
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 private typealias Word = BigInt.Word
 private typealias WordsExpected = (words: [Word], expected: String)

--- a/Tests/BigIntTests/WordTests.swift
+++ b/Tests/BigIntTests/WordTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import BigInt
+@testable import SwiftBigInt
 
 // TODO: Return to `where Word.Magnitude == Word` when SR-13491 is resolved
 struct TestDivision<Word: FixedWidthInteger> {

--- a/docs/docsets/BigInt.docset/Contents/Resources/Documents/index.html
+++ b/docs/docsets/BigInt.docset/Contents/Resources/Documents/index.html
@@ -273,7 +273,7 @@ generic variant that was slower but more flexible.</p>
 <h3 id='a-name-factorial-obligatory-factorial-demo-a' class='heading'><a name="factorial">Obligatory Factorial Demo</a></h3>
 
 <p>It is easy to use <code><a href="Structs/BigInt.html">BigInt</a></code> to calculate the factorial function for any integer:</p>
-<pre class="highlight plaintext"><code>import BigInt
+<pre class="highlight plaintext"><code>import SwiftBigInt
 
 func factorial(_ n: Int) -&gt; BigInt {
     return (1 ... n).map { BigInt($0) }.reduce(BigInt(1), *)

--- a/docs/index.html
+++ b/docs/index.html
@@ -273,7 +273,7 @@ generic variant that was slower but more flexible.</p>
 <h3 id='a-name-factorial-obligatory-factorial-demo-a' class='heading'><a name="factorial">Obligatory Factorial Demo</a></h3>
 
 <p>It is easy to use <code><a href="Structs/BigInt.html">BigInt</a></code> to calculate the factorial function for any integer:</p>
-<pre class="highlight plaintext"><code>import BigInt
+<pre class="highlight plaintext"><code>import SwiftBigInt
 
 func factorial(_ n: Int) -&gt; BigInt {
     return (1 ... n).map { BigInt($0) }.reduce(BigInt(1), *)


### PR DESCRIPTION
Rename module to SwiftBigInt to fix module stability compilation

BREAKING CHANGE: Module name changed from BigInt to SwiftBigInt

## Problem
The module name "BigInt" conflicted with the struct name "public struct BigInt",
causing Swift compiler errors when building with BUILD_LIBRARY_FOR_DISTRIBUTION=YES
(required for XCFramework distribution and module stability):

```
error: 'BigInt' is not a member type of struct 'BigInt.BigInt'
```

## Solution
Renamed the module to "SwiftBigInt" following Swift community conventions
(similar to SwiftNIO, SwiftLog, SwiftCrypto).

## Changes
- Package name: Remains "BigInt" (matches repository name)
- Product name: BigInt → SwiftBigInt
- Module name: BigInt → SwiftBigInt
- Type names: UNCHANGED (BigInt and BigUInt structs remain the same)

## Migration for Consumers
Only import statements need to change:

```swift
// Before (v5.x):
import BigInt

// After (v6.0+):
import SwiftBigInt

// Type names unchanged:
let x = BigInt(100)   // ✓ Still works
let y = BigUInt(50)   // ✓ Still works
```

## Benefits
- ✅ Fixes module stability compilation errors
- ✅ Enables XCFramework distribution without compiler workarounds
- ✅ Eliminates need for -no-verify-emitted-module-interface flag
- ✅ Follows Swift community naming conventions
- ✅ Minimal breaking changes (import statements only)

## Files Modified
- Package.swift: Updated module and product names
- All test files (18 files): Updated imports
- Demo playground files (5 files): Updated imports
- README.md: Added migration guide
- Documentation: Updated import examples

## Version
Requires major version bump: 5.4.0 → 6.0.0

Fixes module interface verification bug when building with library evolution enabled.
