### PR TITLE
Fix Internal _mantissa problem on WASI

### DIFF
--- a/Sources/Floating Point Conversion.swift
+++ b/Sources/Floating Point Conversion.swift
@@ -49,7 +49,7 @@ extension BigUInt {
         guard integer.sign == .plus else { return nil }
         assert(integer.floatingPointClass == .positiveNormal)
 
-        #if os(Linux) || os(Android) || os(Windows)
+        #if os(Linux) || os(Android) || os(Windows) || os(WASI)
         // `Decimal._mantissa` has an internal access level on linux, and it might get
         // deprecated in the future, so keeping the string implementation around for now.
         let significand = BigUInt("\(integer.significand)")!
@@ -163,7 +163,7 @@ public extension Decimal {
 }
 #endif
 
-#if canImport(Foundation) && !(os(Linux) || os(Android) || os(Windows))
+#if canImport(Foundation) && !(os(Linux) || os(Android) || os(Windows) || os(WASI))
 private extension Decimal {
     var mantissaParts: [UInt16] {
         [


### PR DESCRIPTION
## Summary
On WASI, `Decimal` is provided by FoundationEssentials, where `_mantissa`
has `internal` access — the same situation that PR #125 addressed for
Windows and that the original guard handled for Linux/Android.

Without this change, BigInt fails to build for the `wasm32-unknown-wasip1`
SDK