### PR TITLE
Migrate all tests from XCTest to Swift Testing framework

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -77,6 +77,8 @@ jobs:
           echo "SWIFTLY_BIN_DIR=${SWIFTLY_BIN_DIR}" >> "${GITHUB_ENV}"
       - name: Install WebAssembly Swift SDK
         run: swift sdk install https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz --checksum a61f0584c93283589f8b2f42db05c1f9a182b506c2957271402992655591dd7c
+      - name: Install system dependencies
+        run: sudo apt-get -y install libcurl4-openssl-dev
       - name: Build for WebAssembly
         run: swift build --swift-sdk swift-6.3.2-RELEASE_wasm
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           path: ~/.local/share/swiftly/toolchains
           key: swiftly-wasm-6.3.2-${{ runner.os }}
+      - name: Install system dependencies
+        run: sudo apt-get -y install libcurl4-openssl-dev
       - name: Install Swift Toolchain
         run: |
           curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
@@ -77,8 +79,6 @@ jobs:
           echo "SWIFTLY_BIN_DIR=${SWIFTLY_BIN_DIR}" >> "${GITHUB_ENV}"
       - name: Install WebAssembly Swift SDK
         run: swift sdk install https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz --checksum a61f0584c93283589f8b2f42db05c1f9a182b506c2957271402992655591dd7c
-      - name: Install system dependencies
-        run: sudo apt-get -y install libcurl4-openssl-dev
       - name: Build for WebAssembly
         run: swift build --swift-sdk swift-6.3.2-RELEASE_wasm
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.3
+// swift-tools-version:6.0
 //
 //  Package.swift
 //  BigInt
@@ -24,10 +24,8 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "BigInt", path: "Sources",
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
+            name: "BigInt", path: "Sources"),
         .testTarget(
-            name: "BigIntTests", dependencies: ["BigInt"], path: "Tests",
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
+            name: "BigIntTests", dependencies: ["BigInt"], path: "Tests"),
     ]
 )

--- a/Tests/BigIntTests/BigIntTests.swift
+++ b/Tests/BigIntTests/BigIntTests.swift
@@ -5,138 +5,135 @@
 //  Created by Károly Lőrentey on 2015-12-26.
 //  Copyright © 2016-2017 Károly Lőrentey.
 //
-
-import XCTest
+import Testing
 @testable import BigInt
 import Foundation
 
-class BigIntTests: XCTestCase {
+@Suite struct BigIntTests {
     typealias Word = BigInt.Word
 
-    func testSigns() {
-        XCTAssertTrue(BigInt.isSigned)
+    @Test func signs() {
+        #expect(BigInt.isSigned)
 
-        XCTAssertEqual(BigInt().signum(), 0)
-        XCTAssertEqual(BigInt(-2).signum(), -1)
-        XCTAssertEqual(BigInt(-1).signum(), -1)
-        XCTAssertEqual(BigInt(0).signum(), 0)
-        XCTAssertEqual(BigInt(1).signum(), 1)
-        XCTAssertEqual(BigInt(2).signum(), 1)
+        #expect(BigInt().signum() == 0)
+        #expect(BigInt(-2).signum() == -1)
+        #expect(BigInt(-1).signum() == -1)
+        #expect(BigInt(0).signum() == 0)
+        #expect(BigInt(1).signum() == 1)
+        #expect(BigInt(2).signum() == 1)
 
-        XCTAssertEqual(BigInt(words: [0, Word.max]).signum(), -1)
-        XCTAssertEqual(BigInt(words: [0, 1]).signum(), 1)
+        #expect(BigInt(words: [0, Word.max]).signum() == -1)
+        #expect(BigInt(words: [0, 1]).signum() == 1)
     }
 
-    func testInit() {
-        XCTAssertEqual(BigInt().sign, .plus)
-        XCTAssertEqual(BigInt().magnitude, 0)
+    @Test func init_() {
+        #expect(BigInt().sign == .plus)
+        #expect(BigInt().magnitude == 0)
 
-        XCTAssertEqual(BigInt(Int64.min).sign, .minus)
-        XCTAssertEqual(BigInt(Int64.min).magnitude - 1, BigInt(Int64.max).magnitude)
+        #expect(BigInt(Int64.min).sign == .minus)
+        #expect(BigInt(Int64.min).magnitude - 1 == BigInt(Int64.max).magnitude)
 
         let zero = BigInt(0)
-        XCTAssertTrue(zero.magnitude.isZero)
-        XCTAssertEqual(zero.sign, .plus)
+        #expect(zero.magnitude.isZero)
+        #expect(zero.sign == .plus)
 
         let minusOne = BigInt(-1)
-        XCTAssertEqual(minusOne.magnitude, 1)
-        XCTAssertEqual(minusOne.sign, .minus)
+        #expect(minusOne.magnitude == 1)
+        #expect(minusOne.sign == .minus)
 
         let b: BigInt = 42
-        XCTAssertEqual(b.magnitude, 42)
-        XCTAssertEqual(b.sign, .plus)
+        #expect(b.magnitude == 42)
+        #expect(b.sign == .plus)
 
-        XCTAssertEqual(BigInt(UInt64.max).magnitude, BigUInt(UInt64.max))
+        #expect(BigInt(UInt64.max).magnitude == BigUInt(UInt64.max))
 
         let b2: BigInt = "+300"
-        XCTAssertEqual(b2.magnitude, 300)
-        XCTAssertEqual(b2.sign, .plus)
+        #expect(b2.magnitude == 300)
+        #expect(b2.sign == .plus)
 
         let b3: BigInt = "-300"
-        XCTAssertEqual(b3.magnitude, 300)
-        XCTAssertEqual(b3.sign, .minus)
+        #expect(b3.magnitude == 300)
+        #expect(b3.sign == .minus)
 
         // We have to call BigInt.init here because we don't want Literal initialization via coercion (SE-0213)
-        XCTAssertNil(BigInt.init("Not a number"))
-        XCTAssertEqual(BigInt(unicodeScalarLiteral: UnicodeScalar(52)), BigInt(4))
-        XCTAssertEqual(BigInt(extendedGraphemeClusterLiteral: "4"), BigInt(4))
+        #expect(BigInt.init("Not a number") == nil)
+        #expect(BigInt(unicodeScalarLiteral: UnicodeScalar(52)) == BigInt(4))
+        #expect(BigInt(extendedGraphemeClusterLiteral: "4") == BigInt(4))
 
-        XCTAssertEqual(BigInt(words: []), 0)
-        XCTAssertEqual(BigInt(words: [1, 1]), BigInt(1) << Word.bitWidth + 1)
-        XCTAssertEqual(BigInt(words: [1, 2]), BigInt(2) << Word.bitWidth + 1)
-        XCTAssertEqual(BigInt(words: [0, Word.max]), -(BigInt(1) << Word.bitWidth))
-        XCTAssertEqual(BigInt(words: [1, Word.max]), -BigInt(Word.max))
-        XCTAssertEqual(BigInt(words: [1, Word.max, Word.max]), -BigInt(Word.max))
+        #expect(BigInt(words: []) == 0)
+        #expect(BigInt(words: [1, 1]) == BigInt(1) << Word.bitWidth + 1)
+        #expect(BigInt(words: [1, 2]) == BigInt(2) << Word.bitWidth + 1)
+        #expect(BigInt(words: [0, Word.max]) == -(BigInt(1) << Word.bitWidth))
+        #expect(BigInt(words: [1, Word.max]) == -BigInt(Word.max))
+        #expect(BigInt(words: [1, Word.max, Word.max]) == -BigInt(Word.max))
         
-        XCTAssertEqual(BigInt(exactly: 1), BigInt(1))
-        XCTAssertEqual(BigInt(exactly: -1), BigInt(-1))
+        #expect(BigInt(exactly: 1) == BigInt(1))
+        #expect(BigInt(exactly: -1) == BigInt(-1))
     }
 
-    func testInit_FloatingPoint() {
-        XCTAssertEqual(BigInt(42.0), 42)
-        XCTAssertEqual(BigInt(-42.0), -42)
-        XCTAssertEqual(BigInt(42.5), 42)
-        XCTAssertEqual(BigInt(-42.5), -42)
-        XCTAssertEqual(BigInt(exactly: 42.0), 42)
-        XCTAssertEqual(BigInt(exactly: -42.0), -42)
-        XCTAssertNil(BigInt(exactly: 42.5))
-        XCTAssertNil(BigInt(exactly: -42.5))
-        XCTAssertNil(BigInt(exactly: Double.leastNormalMagnitude))
-        XCTAssertNil(BigInt(exactly: Double.leastNonzeroMagnitude))
-        XCTAssertNil(BigInt(exactly: Double.infinity))
-        XCTAssertNil(BigInt(exactly: Double.nan))
-        XCTAssertNil(BigInt(exactly: Double.signalingNaN))
-        XCTAssertEqual(BigInt(clamping: -42), -42)
-        XCTAssertEqual(BigInt(clamping: 42), 42)
-        XCTAssertEqual(BigInt(truncatingIfNeeded: -42), -42)
-        XCTAssertEqual(BigInt(truncatingIfNeeded: 42), 42)
+    @Test func init_FloatingPoint() {
+        #expect(BigInt(42.0) == 42)
+        #expect(BigInt(-42.0) == -42)
+        #expect(BigInt(42.5) == 42)
+        #expect(BigInt(-42.5) == -42)
+        #expect(BigInt(exactly: 42.0) == 42)
+        #expect(BigInt(exactly: -42.0) == -42)
+        #expect(BigInt(exactly: 42.5) == nil)
+        #expect(BigInt(exactly: -42.5) == nil)
+        #expect(BigInt(exactly: Double.leastNormalMagnitude) == nil)
+        #expect(BigInt(exactly: Double.leastNonzeroMagnitude) == nil)
+        #expect(BigInt(exactly: Double.infinity) == nil)
+        #expect(BigInt(exactly: Double.nan) == nil)
+        #expect(BigInt(exactly: Double.signalingNaN) == nil)
+        #expect(BigInt(clamping: -42) == -42)
+        #expect(BigInt(clamping: 42) == 42)
+        #expect(BigInt(truncatingIfNeeded: -42) == -42)
+        #expect(BigInt(truncatingIfNeeded: 42) == 42)
     }
 
-    func testInit_Decimal() throws {
-        XCTAssertEqual(BigInt(exactly: Decimal(0)), 0)
-        XCTAssertEqual(BigInt(exactly: Decimal(Double.nan)), nil)
-        XCTAssertEqual(BigInt(exactly: Decimal(10)), 10)
-        XCTAssertEqual(BigInt(exactly: Decimal(1000)), 1000)
-        XCTAssertEqual(BigInt(exactly: Decimal(1000.1)), nil)
-        XCTAssertEqual(BigInt(exactly: Decimal(1000.9)), nil)
-        XCTAssertEqual(BigInt(exactly: Decimal(1001.5)), nil)
-        XCTAssertEqual(BigInt(exactly: Decimal(UInt.max) + 5), "18446744073709551620")
-        XCTAssertEqual(BigInt(exactly: (Decimal(UInt.max) + 5.5)), nil)
-        XCTAssertEqual(BigInt(exactly: Decimal.greatestFiniteMagnitude),
-                       "3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
-        XCTAssertEqual(BigInt(truncating: Decimal(0)), 0)
-        XCTAssertEqual(BigInt(truncating: Decimal(Double.nan)), nil)
-        XCTAssertEqual(BigInt(truncating: Decimal(10)), 10)
-        XCTAssertEqual(BigInt(truncating: Decimal(1000)), 1000)
-        XCTAssertEqual(BigInt(truncating: Decimal(1000.1)), 1000)
-        XCTAssertEqual(BigInt(truncating: Decimal(1000.9)), 1000)
-        XCTAssertEqual(BigInt(truncating: Decimal(1001.5)), 1001)
-        XCTAssertEqual(BigInt(truncating: Decimal(UInt.max) + 5), "18446744073709551620")
-        XCTAssertEqual(BigInt(truncating: (Decimal(UInt.max) + 5.5)), "18446744073709551620")
+    @Test func init_Decimal() throws {
+        #expect(BigInt(exactly: Decimal(0)) == 0)
+        #expect(BigInt(exactly: Decimal(Double.nan)) == nil)
+        #expect(BigInt(exactly: Decimal(10)) == 10)
+        #expect(BigInt(exactly: Decimal(1000)) == 1000)
+        #expect(BigInt(exactly: Decimal(1000.1)) == nil)
+        #expect(BigInt(exactly: Decimal(1000.9)) == nil)
+        #expect(BigInt(exactly: Decimal(1001.5)) == nil)
+        #expect(BigInt(exactly: Decimal(UInt.max) + 5) == "18446744073709551620")
+        #expect(BigInt(exactly: (Decimal(UInt.max) + 5.5)) == nil)
+        #expect(BigInt(exactly: Decimal.greatestFiniteMagnitude) == "3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+        #expect(BigInt(truncating: Decimal(0)) == 0)
+        #expect(BigInt(truncating: Decimal(Double.nan)) == nil)
+        #expect(BigInt(truncating: Decimal(10)) == 10)
+        #expect(BigInt(truncating: Decimal(1000)) == 1000)
+        #expect(BigInt(truncating: Decimal(1000.1)) == 1000)
+        #expect(BigInt(truncating: Decimal(1000.9)) == 1000)
+        #expect(BigInt(truncating: Decimal(1001.5)) == 1001)
+        #expect(BigInt(truncating: Decimal(UInt.max) + 5) == "18446744073709551620")
+        #expect(BigInt(truncating: (Decimal(UInt.max) + 5.5)) == "18446744073709551620")
 
-        XCTAssertEqual(BigInt(exactly: -Decimal(10)), -10)
-        XCTAssertEqual(BigInt(exactly: -Decimal(1000)), -1000)
-        XCTAssertEqual(BigInt(exactly: -Decimal(1000.1)), nil)
-        XCTAssertEqual(BigInt(exactly: -Decimal(1000.9)), nil)
-        XCTAssertEqual(BigInt(exactly: -Decimal(1001.5)), nil)
-        XCTAssertEqual(BigInt(exactly: -(Decimal(UInt.max) + 5)), "-18446744073709551620")
-        XCTAssertEqual(BigInt(exactly: -(Decimal(UInt.max) + 5.5)), nil)
-        XCTAssertEqual(BigInt(exactly: Decimal.leastFiniteMagnitude),
-                       "-3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
-        XCTAssertEqual(BigInt(truncating: -Decimal(10)), -10)
-        XCTAssertEqual(BigInt(truncating: -Decimal(1000)), -1000)
-        XCTAssertEqual(BigInt(truncating: -Decimal(1000.1)), -1000)
-        XCTAssertEqual(BigInt(truncating: -Decimal(1000.9)), -1000)
-        XCTAssertEqual(BigInt(truncating: -Decimal(1001.5)), -1001)
-        XCTAssertEqual(BigInt(truncating: -(Decimal(UInt.max) + 5)), "-18446744073709551620")
-        XCTAssertEqual(BigInt(truncating: -(Decimal(UInt.max) + 5.5)), "-18446744073709551620")
+        #expect(BigInt(exactly: -Decimal(10)) == -10)
+        #expect(BigInt(exactly: -Decimal(1000)) == -1000)
+        #expect(BigInt(exactly: -Decimal(1000.1)) == nil)
+        #expect(BigInt(exactly: -Decimal(1000.9)) == nil)
+        #expect(BigInt(exactly: -Decimal(1001.5)) == nil)
+        #expect(BigInt(exactly: -(Decimal(UInt.max) + 5)) == "-18446744073709551620")
+        #expect(BigInt(exactly: -(Decimal(UInt.max) + 5.5)) == nil)
+        #expect(BigInt(exactly: Decimal.leastFiniteMagnitude) == "-3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+        #expect(BigInt(truncating: -Decimal(10)) == -10)
+        #expect(BigInt(truncating: -Decimal(1000)) == -1000)
+        #expect(BigInt(truncating: -Decimal(1000.1)) == -1000)
+        #expect(BigInt(truncating: -Decimal(1000.9)) == -1000)
+        #expect(BigInt(truncating: -Decimal(1001.5)) == -1001)
+        #expect(BigInt(truncating: -(Decimal(UInt.max) + 5)) == "-18446744073709551620")
+        #expect(BigInt(truncating: -(Decimal(UInt.max) + 5.5)) == "-18446744073709551620")
     }
 
-    func testInit_Buffer() {
-        func test(_ b: BigInt, _ d: Array<UInt8>, file: StaticString = #file, line: UInt = #line) {
+    @Test func init_Buffer() {
+        func test(_ b: BigInt, _ d: Array<UInt8>) {
             d.withUnsafeBytes { buffer in
                 let initialized = BigInt(buffer)
-                XCTAssertEqual(initialized, b, file: file, line: line)
+                #expect(initialized == b)
             }
         }
         
@@ -155,11 +152,11 @@ class BigIntTests: XCTestCase {
         test((BigInt(0x01) << 64 + BigInt(0x0203040506070809)) * BigInt(-1), [0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])
     }
 
-    func testConversionToFloatingPoint() {
-        func test<F: BinaryFloatingPoint>(_ a: BigInt, _ b: F, file: StaticString = #file, line: UInt = #line)
+    @Test func conversionToFloatingPoint() {
+        func test<F: BinaryFloatingPoint>(_ a: BigInt, _ b: F)
         where F.RawExponent: FixedWidthInteger, F.RawSignificand: FixedWidthInteger {
                 let f = F(a)
-                XCTAssertEqual(f, b, file: file, line: line)
+                #expect(f == b)
         }
 
         for i in -100 ..< 100 {
@@ -186,27 +183,27 @@ class BigIntTests: XCTestCase {
         test(BigInt(words: convertWords([0, 0xFFFFFF0000000000, 0])),
              Float.greatestFiniteMagnitude)
 
-        XCTAssertEqual(Decimal(BigInt(0)), 0)
-        XCTAssertEqual(Decimal(BigInt(20)), 20)
-        XCTAssertEqual(Decimal(BigInt(123456789)), 123456789)
-        XCTAssertEqual(Decimal(BigInt(exactly: Decimal.greatestFiniteMagnitude)!), .greatestFiniteMagnitude)
-        XCTAssertEqual(Decimal(BigInt(exactly: Decimal.greatestFiniteMagnitude)! * 2), .greatestFiniteMagnitude)
-        XCTAssertEqual(Decimal(-BigInt(0)), 0)
-        XCTAssertEqual(Decimal(-BigInt(20)), -20)
-        XCTAssertEqual(Decimal(-BigInt(123456789)), -123456789)
-        XCTAssertEqual(Decimal(-BigInt(exactly: Decimal.greatestFiniteMagnitude)!), -.greatestFiniteMagnitude)
-        XCTAssertEqual(Decimal(-BigInt(exactly: Decimal.greatestFiniteMagnitude)! * 2), -.greatestFiniteMagnitude)
+        #expect(Decimal(BigInt(0)) == 0)
+        #expect(Decimal(BigInt(20)) == 20)
+        #expect(Decimal(BigInt(123456789)) == 123456789)
+        #expect(Decimal(BigInt(exactly: Decimal.greatestFiniteMagnitude)!) == .greatestFiniteMagnitude)
+        #expect(Decimal(BigInt(exactly: Decimal.greatestFiniteMagnitude)! * 2) == .greatestFiniteMagnitude)
+        #expect(Decimal(-BigInt(0)) == 0)
+        #expect(Decimal(-BigInt(20)) == -20)
+        #expect(Decimal(-BigInt(123456789)) == -123456789)
+        #expect(Decimal(-BigInt(exactly: Decimal.greatestFiniteMagnitude)!) == -.greatestFiniteMagnitude)
+        #expect(Decimal(-BigInt(exactly: Decimal.greatestFiniteMagnitude)! * 2) == -.greatestFiniteMagnitude)
 
     }
 
-    func testTwosComplement() {
-        func check(_ a: [Word], _ b: [Word], file: StaticString = #file, line: UInt = #line) {
+    @Test func twosComplement() {
+        func check(_ a: [Word], _ b: [Word]) {
             var a2 = a
             a2.twosComplement()
-            XCTAssertEqual(a2, b, file: file, line: line)
+            #expect(a2 == b)
             var b2 = b
             b2.twosComplement()
-            XCTAssertEqual(b2, a, file: file, line: line)
+            #expect(b2 == a)
         }
         check([1], [Word.max])
         check([Word.max], [1])
@@ -219,159 +216,148 @@ class BigIntTests: XCTestCase {
         check([0, 0, 1, 0, 0, 0], [0, 0, Word.max, Word.max, Word.max, Word.max])
     }
 
-    func testSign() {
-        XCTAssertEqual(BigInt(-1).sign, .minus)
-        XCTAssertEqual(BigInt(0).sign, .plus)
-        XCTAssertEqual(BigInt(1).sign, .plus)
+    @Test func sign() {
+        #expect(BigInt(-1).sign == .minus)
+        #expect(BigInt(0).sign == .plus)
+        #expect(BigInt(1).sign == .plus)
     }
 
-    func testBitWidth() {
-        XCTAssertEqual(BigInt(0).bitWidth, 0)
-        XCTAssertEqual(BigInt(1).bitWidth, 2)
-        XCTAssertEqual(BigInt(-1).bitWidth, 2)
-        XCTAssertEqual((BigInt(1) << 64).bitWidth, Word.bitWidth + 2)
-        XCTAssertEqual(BigInt(Word.max).bitWidth, Word.bitWidth + 1)
-        XCTAssertEqual(BigInt(Word.max >> 1).bitWidth, Word.bitWidth)
+    @Test func bitWidth() {
+        #expect(BigInt(0).bitWidth == 0)
+        #expect(BigInt(1).bitWidth == 2)
+        #expect(BigInt(-1).bitWidth == 2)
+        #expect((BigInt(1) << 64).bitWidth == Word.bitWidth + 2)
+        #expect(BigInt(Word.max).bitWidth == Word.bitWidth + 1)
+        #expect(BigInt(Word.max >> 1).bitWidth == Word.bitWidth)
     }
 
-    func testTrailingZeroBitCount() {
-        XCTAssertEqual(BigInt(0).trailingZeroBitCount, 0)
-        XCTAssertEqual(BigInt(1).trailingZeroBitCount, 0)
-        XCTAssertEqual(BigInt(-1).trailingZeroBitCount, 0)
-        XCTAssertEqual(BigInt(2).trailingZeroBitCount, 1)
-        XCTAssertEqual(BigInt(Word.max).trailingZeroBitCount, 0)
-        XCTAssertEqual(BigInt(-2).trailingZeroBitCount, 1)
-        XCTAssertEqual(-BigInt(Word.max).trailingZeroBitCount, 0)
-        XCTAssertEqual((BigInt(1) << 100).trailingZeroBitCount, 100)
-        XCTAssertEqual(((-BigInt(1)) << 100).trailingZeroBitCount, 100)
+    @Test func trailingZeroBitCount() {
+        #expect(BigInt(0).trailingZeroBitCount == 0)
+        #expect(BigInt(1).trailingZeroBitCount == 0)
+        #expect(BigInt(-1).trailingZeroBitCount == 0)
+        #expect(BigInt(2).trailingZeroBitCount == 1)
+        #expect(BigInt(Word.max).trailingZeroBitCount == 0)
+        #expect(BigInt(-2).trailingZeroBitCount == 1)
+        #expect(-BigInt(Word.max).trailingZeroBitCount == 0)
+        #expect((BigInt(1) << 100).trailingZeroBitCount == 100)
+        #expect(((-BigInt(1)) << 100).trailingZeroBitCount == 100)
     }
 
-    func testWords() {
-        XCTAssertEqual(Array(BigInt(0).words), [])
-        XCTAssertEqual(Array(BigInt(1).words), [1])
-        XCTAssertEqual(Array(BigInt(-1).words), [Word.max])
+    @Test func words() {
+        #expect(Array(BigInt(0).words) == [])
+        #expect(Array(BigInt(1).words) == [1])
+        #expect(Array(BigInt(-1).words) == [Word.max])
 
         let highBit = (1 as Word) << (Word.bitWidth - 1)
-        XCTAssertEqual(Array(BigInt(highBit).words), [highBit, 0])
-        XCTAssertEqual(Array((-BigInt(highBit)).words), [highBit, Word.max])
+        #expect(Array(BigInt(highBit).words) == [highBit, 0])
+        #expect(Array((-BigInt(highBit)).words) == [highBit, Word.max])
 
-        XCTAssertEqual(Array(BigInt(sign: .plus, magnitude: BigUInt(words: [Word.max])).words), [Word.max, 0])
-        XCTAssertEqual(Array(BigInt(sign: .minus, magnitude: BigUInt(words: [Word.max])).words), [1, Word.max])
+        #expect(Array(BigInt(sign: .plus, magnitude: BigUInt(words: [Word.max])).words) == [Word.max, 0])
+        #expect(Array(BigInt(sign: .minus, magnitude: BigUInt(words: [Word.max])).words) == [1, Word.max])
 
-        XCTAssertEqual(Array((BigInt(1) << Word.bitWidth).words), [0, 1])
-        XCTAssertEqual(Array((-(BigInt(1) << Word.bitWidth)).words), [0, Word.max])
+        #expect(Array((BigInt(1) << Word.bitWidth).words) == [0, 1])
+        #expect(Array((-(BigInt(1) << Word.bitWidth)).words) == [0, Word.max])
 
-        XCTAssertEqual(Array((BigInt(42) << Word.bitWidth).words), [0, 42])
-        XCTAssertEqual(Array((-(BigInt(42) << Word.bitWidth)).words), [0, Word.max - 41])
+        #expect(Array((BigInt(42) << Word.bitWidth).words) == [0, 42])
+        #expect(Array((-(BigInt(42) << Word.bitWidth)).words) == [0, Word.max - 41])
 
         let huge = BigUInt(words: [0, 1, 2, 3, 4])
-        XCTAssertEqual(Array(BigInt(sign: .plus, magnitude: huge).words), [0, 1, 2, 3, 4])
-        XCTAssertEqual(Array(BigInt(sign: .minus, magnitude: huge).words),
-                       [0, Word.max, ~2, ~3, ~4] as [Word])
+        #expect(Array(BigInt(sign: .plus, magnitude: huge).words) == [0, 1, 2, 3, 4])
+        #expect(Array(BigInt(sign: .minus, magnitude: huge).words) == [0, Word.max, ~2, ~3, ~4] as [Word])
 
 
-        XCTAssertEqual(BigInt(1).words[100], 0)
-        XCTAssertEqual(BigInt(-1).words[100], Word.max)
+        #expect(BigInt(1).words[100] == 0)
+        #expect(BigInt(-1).words[100] == Word.max)
 
-        XCTAssertEqual(BigInt(words: [0, 1, 2, 3, 4]).words.indices, 0 ..< 5)
+        #expect(BigInt(words: [0, 1, 2, 3, 4]).words.indices == 0 ..< 5)
     }
 
-    func testComplement() {
-        XCTAssertEqual(~BigInt(-3), BigInt(2))
-        XCTAssertEqual(~BigInt(-2), BigInt(1))
-        XCTAssertEqual(~BigInt(-1), BigInt(0))
-        XCTAssertEqual(~BigInt(0), BigInt(-1))
-        XCTAssertEqual(~BigInt(1), BigInt(-2))
-        XCTAssertEqual(~BigInt(2), BigInt(-3))
+    @Test func complement() {
+        #expect(~BigInt(-3) == BigInt(2))
+        #expect(~BigInt(-2) == BigInt(1))
+        #expect(~BigInt(-1) == BigInt(0))
+        #expect(~BigInt(0) == BigInt(-1))
+        #expect(~BigInt(1) == BigInt(-2))
+        #expect(~BigInt(2) == BigInt(-3))
 
-        XCTAssertEqual(~BigInt(words: [1, 2, 3, 4]),
-                       BigInt(words: [Word.max - 1, Word.max - 2, Word.max - 3, Word.max - 4]))
-        XCTAssertEqual(~BigInt(words: [Word.max - 1, Word.max - 2, Word.max - 3, Word.max - 4]),
-                       BigInt(words: [1, 2, 3, 4]))
+        #expect(~BigInt(words: [1, 2, 3, 4]) == BigInt(words: [Word.max - 1, Word.max - 2, Word.max - 3, Word.max - 4]))
+        #expect(~BigInt(words: [Word.max - 1, Word.max - 2, Word.max - 3, Word.max - 4]) == BigInt(words: [1, 2, 3, 4]))
     }
 
-    func testBinaryAnd() {
-        XCTAssertEqual(BigInt(1) & BigInt(2), 0)
-        XCTAssertEqual(BigInt(-1) & BigInt(2), 2)
-        XCTAssertEqual(BigInt(-1) & BigInt(words: [1, 2, 3, 4]), BigInt(words: [1, 2, 3, 4]))
-        XCTAssertEqual(BigInt(-1) & -BigInt(words: [1, 2, 3, 4]), -BigInt(words: [1, 2, 3, 4]))
-        XCTAssertEqual(BigInt(Word.max) & BigInt(words: [1, 2, 3, 4]), BigInt(1))
-        XCTAssertEqual(BigInt(Word.max) & BigInt(words: [Word.max, 1, 2]), BigInt(Word.max))
-        XCTAssertEqual(BigInt(Word.max) & BigInt(words: [Word.max, Word.max - 1]), BigInt(Word.max))
+    @Test func binaryAnd() {
+        #expect(BigInt(1) & BigInt(2) == 0)
+        #expect(BigInt(-1) & BigInt(2) == 2)
+        #expect(BigInt(-1) & BigInt(words: [1, 2, 3, 4]) == BigInt(words: [1, 2, 3, 4]))
+        #expect(BigInt(-1) & -BigInt(words: [1, 2, 3, 4]) == -BigInt(words: [1, 2, 3, 4]))
+        #expect(BigInt(Word.max) & BigInt(words: [1, 2, 3, 4]) == BigInt(1))
+        #expect(BigInt(Word.max) & BigInt(words: [Word.max, 1, 2]) == BigInt(Word.max))
+        #expect(BigInt(Word.max) & BigInt(words: [Word.max, Word.max - 1]) == BigInt(Word.max))
     }
 
-    func testBinaryOr() {
-        XCTAssertEqual(BigInt(1) | BigInt(2), 3)
-        XCTAssertEqual(BigInt(-1) | BigInt(2), -1)
-        XCTAssertEqual(BigInt(-1) | BigInt(words: [1, 2, 3, 4]), -1)
-        XCTAssertEqual(BigInt(-1) | -BigInt(words: [1, 2, 3, 4]), -1)
-        XCTAssertEqual(BigInt(Word.max) | BigInt(words: [1, 2, 3, 4]),
-                       BigInt(words: [Word.max, 2, 3, 4]))
-        XCTAssertEqual(BigInt(Word.max) | BigInt(words: [1, 2, 3, Word.max]),
-                       BigInt(words: [Word.max, 2, 3, Word.max]))
-        XCTAssertEqual(BigInt(Word.max) | BigInt(words: [Word.max - 1, Word.max - 1]),
-                       BigInt(words: [Word.max, Word.max - 1]))
+    @Test func binaryOr() {
+        #expect(BigInt(1) | BigInt(2) == 3)
+        #expect(BigInt(-1) | BigInt(2) == -1)
+        #expect(BigInt(-1) | BigInt(words: [1, 2, 3, 4]) == -1)
+        #expect(BigInt(-1) | -BigInt(words: [1, 2, 3, 4]) == -1)
+        #expect(BigInt(Word.max) | BigInt(words: [1, 2, 3, 4]) == BigInt(words: [Word.max, 2, 3, 4]))
+        #expect(BigInt(Word.max) | BigInt(words: [1, 2, 3, Word.max]) == BigInt(words: [Word.max, 2, 3, Word.max]))
+        #expect(BigInt(Word.max) | BigInt(words: [Word.max - 1, Word.max - 1]) == BigInt(words: [Word.max, Word.max - 1]))
     }
 
-    func testBinaryXor() {
-        XCTAssertEqual(BigInt(1) ^ BigInt(2), 3)
-        XCTAssertEqual(BigInt(-1) ^ BigInt(2), -3)
-        XCTAssertEqual(BigInt(1) ^ BigInt(-2), -1)
-        XCTAssertEqual(BigInt(-1) ^ BigInt(-2), 1)
-        XCTAssertEqual(BigInt(-1) ^ BigInt(words: [1, 2, 3, 4]),
-                       BigInt(words: [~1, ~2, ~3, ~4] as [Word]))
-        XCTAssertEqual(BigInt(-1) ^ -BigInt(words: [1, 2, 3, 4]),
-                       BigInt(words: [0, 2, 3, 4]))
-        XCTAssertEqual(BigInt(Word.max) ^ BigInt(words: [1, 2, 3, 4]),
-                       BigInt(words: [~1, 2, 3, 4] as [Word]))
-        XCTAssertEqual(BigInt(Word.max) ^ BigInt(words: [1, 2, 3, Word.max]),
-                       BigInt(words: [~1, 2, 3, Word.max] as [Word]))
-        XCTAssertEqual(BigInt(Word.max) ^ BigInt(words: [Word.max - 1, Word.max - 1]),
-                       BigInt(words: [1, Word.max - 1]))
+    @Test func binaryXor() {
+        #expect(BigInt(1) ^ BigInt(2) == 3)
+        #expect(BigInt(-1) ^ BigInt(2) == -3)
+        #expect(BigInt(1) ^ BigInt(-2) == -1)
+        #expect(BigInt(-1) ^ BigInt(-2) == 1)
+        #expect(BigInt(-1) ^ BigInt(words: [1, 2, 3, 4]) == BigInt(words: [~1, ~2, ~3, ~4] as [Word]))
+        #expect(BigInt(-1) ^ -BigInt(words: [1, 2, 3, 4]) == BigInt(words: [0, 2, 3, 4]))
+        #expect(BigInt(Word.max) ^ BigInt(words: [1, 2, 3, 4]) == BigInt(words: [~1, 2, 3, 4] as [Word]))
+        #expect(BigInt(Word.max) ^ BigInt(words: [1, 2, 3, Word.max]) == BigInt(words: [~1, 2, 3, Word.max] as [Word]))
+        #expect(BigInt(Word.max) ^ BigInt(words: [Word.max - 1, Word.max - 1]) == BigInt(words: [1, Word.max - 1]))
     }
 
-    func testConversionToString() {
+    @Test func conversionToString() {
         let b = BigInt(-256)
-        XCTAssertEqual(b.description, "-256")
-        XCTAssertEqual(String(b, radix: 16, uppercase: true), "-100")
+        #expect(b.description == "-256")
+        #expect(String(b, radix: 16, uppercase: true) == "-100")
         let pql = b.playgroundDescription as? String
         if pql == "-256 (9 bits)" {}
         else {
-            XCTFail("Unexpected Playground Quick Look: \(pql ?? "nil")")
+            Issue.record("Unexpected Playground Quick Look: \(pql ?? "nil")")
         }
     }
 
-    func testComparable() {
-        XCTAssertTrue(BigInt(1) == BigInt(1))
-        XCTAssertFalse(BigInt(1) == BigInt(-1))
+    @Test func comparable() {
+        #expect(BigInt(1) == BigInt(1))
+        #expect(BigInt(1) != BigInt(-1))
 
-        XCTAssertTrue(BigInt(1) < BigInt(42))
-        XCTAssertFalse(BigInt(1) < -BigInt(42))
-        XCTAssertTrue(BigInt(-1) < BigInt(42))
-        XCTAssertTrue(BigInt(-42) < BigInt(-1))
+        #expect(BigInt(1) < BigInt(42))
+        #expect(!(BigInt(1) < BigInt(-42)))
+        #expect(BigInt(-1) < BigInt(42))
+        #expect(BigInt(-42) < BigInt(-1))
     }
 
-    func testHashable() {
-        XCTAssertEqual(BigInt(1).hashValue, BigInt(1).hashValue)
-        XCTAssertNotEqual(BigInt(1).hashValue, BigInt(2).hashValue)
-        XCTAssertNotEqual(BigInt(42).hashValue, BigInt(-42).hashValue)
-        XCTAssertNotEqual(BigInt(1).hashValue, BigInt(-1).hashValue)
+    @Test func hashable() {
+        #expect(BigInt(1).hashValue == BigInt(1).hashValue)
+        #expect(BigInt(1).hashValue != BigInt(2).hashValue)
+        #expect(BigInt(42).hashValue != BigInt(-42).hashValue)
+        #expect(BigInt(1).hashValue != BigInt(-1).hashValue)
     }
 
-    func testStrideable() {
-        XCTAssertEqual(BigInt(1).advanced(by: 100), 101)
-        XCTAssertEqual(BigInt(Word.max).advanced(by: 1 as BigInt.Stride), BigInt(1) << Word.bitWidth)
+    @Test func strideable() {
+        #expect(BigInt(1).advanced(by: 100) == 101)
+        #expect(BigInt(Word.max).advanced(by: 1 as BigInt.Stride) == BigInt(1) << Word.bitWidth)
 
-        XCTAssertEqual(BigInt(Word.max).distance(to: BigInt(words: [0, 1])), BigInt(1))
-        XCTAssertEqual(BigInt(words: [0, 1]).distance(to: BigInt(Word.max)), BigInt(-1))
-        XCTAssertEqual(BigInt(0).distance(to: BigInt(words: [0, 1])), BigInt(words: [0, 1]))
+        #expect(BigInt(Word.max).distance(to: BigInt(words: [0, 1])) == BigInt(1))
+        #expect(BigInt(words: [0, 1]).distance(to: BigInt(Word.max)) == BigInt(-1))
+        #expect(BigInt(0).distance(to: BigInt(words: [0, 1])) == BigInt(words: [0, 1]))
     }
 
-    func compare(_ a: Int, _ b: Int, r: Int, file: StaticString = #file, line: UInt = #line, op: (BigInt, BigInt) -> BigInt) {
-        XCTAssertEqual(op(BigInt(a), BigInt(b)), BigInt(r), file: file, line: line)
+    func compare(_ a: Int, _ b: Int, r: Int, op: (BigInt, BigInt) -> BigInt) {
+        #expect(op(BigInt(a), BigInt(b)) == BigInt(r))
     }
 
-    func testAddition() {
+    @Test func addition() {
         compare(0, 0, r: 0, op: +)
         compare(1, 2, r: 3, op: +)
         compare(1, -2, r: -1, op: +)
@@ -380,13 +366,13 @@ class BigIntTests: XCTestCase {
         compare(2, -1, r: 1, op: +)
     }
 
-    func testNegation() {
-        XCTAssertEqual(-BigInt(0), BigInt(0))
-        XCTAssertEqual(-BigInt(1), BigInt(-1))
-        XCTAssertEqual(-BigInt(-1), BigInt(1))
+    @Test func negation() {
+        #expect(-BigInt(0) == BigInt(0))
+        #expect(-BigInt(1) == BigInt(-1))
+        #expect(-BigInt(-1) == BigInt(1))
     }
 
-    func testSubtraction() {
+    @Test func subtraction() {
         compare(0, 0, r: 0, op: -)
         compare(2, 1, r: 1, op: -)
         compare(2, -1, r: 3, op: -)
@@ -394,7 +380,7 @@ class BigIntTests: XCTestCase {
         compare(-2, -1, r: -1, op: -)
     }
 
-    func testMultiplication() {
+    @Test func multiplication() {
         compare(0, 0, r: 0, op: *)
         compare(0, 1, r: 0, op: *)
         compare(1, 0, r: 0, op: *)
@@ -406,11 +392,11 @@ class BigIntTests: XCTestCase {
         compare(-2, -3, r: 6, op: *)
     }
 
-    func testQuotientAndRemainder() {
-        func compare(_ a: BigInt, _ b: BigInt, r: (BigInt, BigInt), file: StaticString = #file, line: UInt = #line) {
+    @Test func quotientAndRemainder() {
+        func compare(_ a: BigInt, _ b: BigInt, r: (BigInt, BigInt)) {
             let actual = a.quotientAndRemainder(dividingBy: b)
-            XCTAssertEqual(actual.quotient, r.0, "quotient", file: file, line: line)
-            XCTAssertEqual(actual.remainder, r.1, "remainder", file: file, line: line)
+            #expect(actual.quotient == r.0, "quotient")
+            #expect(actual.remainder == r.1, "remainder")
         }
 
         compare(0, 1, r: (0, 0))
@@ -421,7 +407,7 @@ class BigIntTests: XCTestCase {
         compare(-7, -4, r: (1, -3))
     }
 
-    func testDivision() {
+    @Test func division() {
         compare(0, 1, r: 0, op: /)
         compare(0, -1, r: 0, op: /)
         compare(7, 4, r: 1, op: /)
@@ -430,7 +416,7 @@ class BigIntTests: XCTestCase {
         compare(-7, -4, r: 1, op: /)
     }
 
-    func testRemainder() {
+    @Test func remainder() {
         compare(0, 1, r: 0, op: %)
         compare(0, -1, r: 0, op: %)
         compare(7, 4, r: 3, op: %)
@@ -439,212 +425,210 @@ class BigIntTests: XCTestCase {
         compare(-7, -4, r:-3, op: %)
     }
 
-    func testModulo() {
-        XCTAssertEqual(BigInt(22).modulus(5), 2)
-        XCTAssertEqual(BigInt(-22).modulus(5), 3)
-        XCTAssertEqual(BigInt(22).modulus(-5), 2)
-        XCTAssertEqual(BigInt(-22).modulus(-5), 3)
+    @Test func modulo() {
+        #expect(BigInt(22).modulus(5) == 2)
+        #expect(BigInt(-22).modulus(5) == 3)
+        #expect(BigInt(22).modulus(-5) == 2)
+        #expect(BigInt(-22).modulus(-5) == 3)
     }
 
-    func testStrideableRequirements() {
-        XCTAssertEqual(5, BigInt(3).advanced(by: 2))
-        XCTAssertEqual(2, BigInt(3).distance(to: 5))
+    @Test func strideableRequirements() {
+        #expect(5 == BigInt(3).advanced(by: 2))
+        #expect(2 == BigInt(3).distance(to: 5))
     }
 
-    func testAbsoluteValuableRequirements() {
-        XCTAssertEqual(BigInt(5), abs(5 as BigInt))
-        XCTAssertEqual(BigInt(0), abs(0 as BigInt))
-        XCTAssertEqual(BigInt(5), abs(-5 as BigInt))
+    @Test func absoluteValuableRequirements() {
+        #expect(BigInt(5) == abs(5 as BigInt))
+        #expect(BigInt(0) == abs(0 as BigInt))
+        #expect(BigInt(5) == abs(-5 as BigInt))
     }
 
-    func testIntegerArithmeticRequirements() {
-        XCTAssertEqual(3 as Int64, Int64(3 as BigInt))
-        XCTAssertEqual(-3 as Int64, Int64(-3 as BigInt))
+    @Test func integerArithmeticRequirements() {
+        #expect(3 as Int64 == Int64(3 as BigInt))
+        #expect(-3 as Int64 == Int64(-3 as BigInt))
     }
 
-    func testAssignmentOperators() {
+    @Test func assignmentOperators() {
         var a = BigInt(1)
         a += 13
-        XCTAssertEqual(a, 14)
+        #expect(a == 14)
 
         a -= 7
-        XCTAssertEqual(a, 7)
+        #expect(a == 7)
 
         a *= 3
-        XCTAssertEqual(a, 21)
+        #expect(a == 21)
 
         a /= 2
-        XCTAssertEqual(a, 10)
+        #expect(a == 10)
 
         a %= 7
-        XCTAssertEqual(a, 3)
+        #expect(a == 3)
     }
 
-    func testExponentiation() {
-        XCTAssertEqual(BigInt(0).power(0), 1)
-        XCTAssertEqual(BigInt(0).power(1), 0)
-        XCTAssertEqual(BigInt(0).power(2), 0)
+    @Test func exponentiation() {
+        #expect(BigInt(0).power(0) == 1)
+        #expect(BigInt(0).power(1) == 0)
+        #expect(BigInt(0).power(2) == 0)
 
-        XCTAssertEqual(BigInt(1).power(-2), 1)
-        XCTAssertEqual(BigInt(1).power(-1), 1)
-        XCTAssertEqual(BigInt(1).power(0), 1)
-        XCTAssertEqual(BigInt(1).power(1), 1)
-        XCTAssertEqual(BigInt(1).power(2), 1)
+        #expect(BigInt(1).power(-2) == 1)
+        #expect(BigInt(1).power(-1) == 1)
+        #expect(BigInt(1).power(0) == 1)
+        #expect(BigInt(1).power(1) == 1)
+        #expect(BigInt(1).power(2) == 1)
 
-        XCTAssertEqual(BigInt(2).power(-4), 0)
-        XCTAssertEqual(BigInt(2).power(-3), 0)
-        XCTAssertEqual(BigInt(2).power(-2), 0)
-        XCTAssertEqual(BigInt(2).power(-1), 0)
-        XCTAssertEqual(BigInt(2).power(0), 1)
-        XCTAssertEqual(BigInt(2).power(1), 2)
-        XCTAssertEqual(BigInt(2).power(2), 4)
-        XCTAssertEqual(BigInt(2).power(3), 8)
-        XCTAssertEqual(BigInt(2).power(4), 16)
+        #expect(BigInt(2).power(-4) == 0)
+        #expect(BigInt(2).power(-3) == 0)
+        #expect(BigInt(2).power(-2) == 0)
+        #expect(BigInt(2).power(-1) == 0)
+        #expect(BigInt(2).power(0) == 1)
+        #expect(BigInt(2).power(1) == 2)
+        #expect(BigInt(2).power(2) == 4)
+        #expect(BigInt(2).power(3) == 8)
+        #expect(BigInt(2).power(4) == 16)
 
-        XCTAssertEqual(BigInt(-1).power(-4), 1)
-        XCTAssertEqual(BigInt(-1).power(-3), -1)
-        XCTAssertEqual(BigInt(-1).power(-2), 1)
-        XCTAssertEqual(BigInt(-1).power(-1), -1)
-        XCTAssertEqual(BigInt(-1).power(0), 1)
-        XCTAssertEqual(BigInt(-1).power(1), -1)
-        XCTAssertEqual(BigInt(-1).power(2), 1)
-        XCTAssertEqual(BigInt(-1).power(3), -1)
-        XCTAssertEqual(BigInt(-1).power(4), 1)
+        #expect(BigInt(-1).power(-4) == 1)
+        #expect(BigInt(-1).power(-3) == -1)
+        #expect(BigInt(-1).power(-2) == 1)
+        #expect(BigInt(-1).power(-1) == -1)
+        #expect(BigInt(-1).power(0) == 1)
+        #expect(BigInt(-1).power(1) == -1)
+        #expect(BigInt(-1).power(2) == 1)
+        #expect(BigInt(-1).power(3) == -1)
+        #expect(BigInt(-1).power(4) == 1)
 
-        XCTAssertEqual(BigInt(-2).power(-4), 0)
-        XCTAssertEqual(BigInt(-2).power(-3), 0)
-        XCTAssertEqual(BigInt(-2).power(-2), 0)
-        XCTAssertEqual(BigInt(-2).power(-1), 0)
-        XCTAssertEqual(BigInt(-2).power(0), 1)
-        XCTAssertEqual(BigInt(-2).power(1), -2)
-        XCTAssertEqual(BigInt(-2).power(2), 4)
-        XCTAssertEqual(BigInt(-2).power(3), -8)
-        XCTAssertEqual(BigInt(-2).power(4), 16)
+        #expect(BigInt(-2).power(-4) == 0)
+        #expect(BigInt(-2).power(-3) == 0)
+        #expect(BigInt(-2).power(-2) == 0)
+        #expect(BigInt(-2).power(-1) == 0)
+        #expect(BigInt(-2).power(0) == 1)
+        #expect(BigInt(-2).power(1) == -2)
+        #expect(BigInt(-2).power(2) == 4)
+        #expect(BigInt(-2).power(3) == -8)
+        #expect(BigInt(-2).power(4) == 16)
     }
 
-    func testModularExponentiation() {
+    @Test func modularExponentiation() {
         for i in -5 ... 5 {
             for j in -5 ... 5 {
                 for m in [-7, -5, -3, -2, -1, 1, 2, 3, 5, 7] {
                     guard i != 0 || j >= 0 else { continue }
-                    XCTAssertEqual(BigInt(i).power(BigInt(j), modulus: BigInt(m)),
-                                   BigInt(i).power(j).modulus(BigInt(m)),
-                                   "\(i), \(j), \(m)")
+                    #expect(BigInt(i).power(BigInt(j), modulus: BigInt(m)) == BigInt(i).power(j).modulus(BigInt(m)), Comment(rawValue: "\(i), \(j), \(m)"))
                 }
             }
         }
     }
 
-    func testSquareRoot() {
-        XCTAssertEqual(BigInt(0).squareRoot(), 0)
-        XCTAssertEqual(BigInt(1).squareRoot(), 1)
-        XCTAssertEqual(BigInt(2).squareRoot(), 1)
-        XCTAssertEqual(BigInt(3).squareRoot(), 1)
-        XCTAssertEqual(BigInt(4).squareRoot(), 2)
-        XCTAssertEqual(BigInt(5).squareRoot(), 2)
-        XCTAssertEqual(BigInt(9).squareRoot(), 3)
+    @Test func squareRoot() {
+        #expect(BigInt(0).squareRoot() == 0)
+        #expect(BigInt(1).squareRoot() == 1)
+        #expect(BigInt(2).squareRoot() == 1)
+        #expect(BigInt(3).squareRoot() == 1)
+        #expect(BigInt(4).squareRoot() == 2)
+        #expect(BigInt(5).squareRoot() == 2)
+        #expect(BigInt(9).squareRoot() == 3)
     }
 
-    func testGCD() {
-        XCTAssertEqual(BigInt(12).greatestCommonDivisor(with: 15), 3)
-        XCTAssertEqual(BigInt(-12).greatestCommonDivisor(with: 15), 3)
-        XCTAssertEqual(BigInt(12).greatestCommonDivisor(with: -15), 3)
-        XCTAssertEqual(BigInt(-12).greatestCommonDivisor(with: -15), 3)
+    @Test func gCD() {
+        #expect(BigInt(12).greatestCommonDivisor(with: 15) == 3)
+        #expect(BigInt(-12).greatestCommonDivisor(with: 15) == 3)
+        #expect(BigInt(12).greatestCommonDivisor(with: -15) == 3)
+        #expect(BigInt(-12).greatestCommonDivisor(with: -15) == 3)
     }
 
-    func testInverse() {
+    @Test func inverse() {
         for base in -100 ... 100 {
             for modulus in [2, 3, 4, 5] {
                 let base = BigInt(base)
                 let modulus = BigInt(modulus)
                 if let inverse = base.inverse(modulus) {
-                    XCTAssertEqual((base * inverse).modulus(modulus), 1, "\(base), \(modulus), \(inverse)")
+                    #expect((base * inverse).modulus(modulus) == 1, "\(base), \(modulus), \(inverse)")
                 }
                 else {
-                    XCTAssertGreaterThan(BigInt(base).greatestCommonDivisor(with: modulus), 1, "\(base), \(modulus)")
+                    #expect(BigInt(base).greatestCommonDivisor(with: modulus) != BigInt(1), Comment(rawValue: "\(base), \(modulus)"))
                 }
             }
         }
     }
 
-    func testPrimes() {
-        XCTAssertFalse(BigInt(-7).isPrime())
-        XCTAssertTrue(BigInt(103).isPrime())
+    @Test func primes() {
+        #expect(!BigInt(-7).isPrime())
+        #expect(BigInt(103).isPrime())
 
-        XCTAssertFalse(BigInt(-3_215_031_751).isStrongProbablePrime(7))
-        XCTAssertTrue(BigInt(3_215_031_751).isStrongProbablePrime(7))
-        XCTAssertFalse(BigInt(3_215_031_751).isPrime())
+        #expect(!BigInt(-3_215_031_751).isStrongProbablePrime(7))
+        #expect(BigInt(3_215_031_751).isStrongProbablePrime(7))
+        #expect(!BigInt(3_215_031_751).isPrime())
     }
 
-    func testShifts() {
-        XCTAssertEqual(BigInt(1) << Word.bitWidth, BigInt(words: [0, 1]))
-        XCTAssertEqual(BigInt(-1) << Word.bitWidth, BigInt(words: [0, Word.max]))
-        XCTAssertEqual(BigInt(words: [0, 1]) << -Word.bitWidth, BigInt(1))
+    @Test func shifts() {
+        #expect(BigInt(1) << Word.bitWidth == BigInt(words: [0, 1]))
+        #expect(BigInt(-1) << Word.bitWidth == BigInt(words: [0, Word.max]))
+        #expect(BigInt(words: [0, 1]) << -Word.bitWidth == BigInt(1))
 
-        XCTAssertEqual(BigInt(words: [0, 1]) >> Word.bitWidth, BigInt(1))
-        XCTAssertEqual(BigInt(-1) >> Word.bitWidth, BigInt(-1))
-        XCTAssertEqual(BigInt(1) >> Word.bitWidth, BigInt(0))
-        XCTAssertEqual(BigInt(words: [0, Word.max]) >> Word.bitWidth, BigInt(-1))
-        XCTAssertEqual(BigInt(1) >> -Word.bitWidth, BigInt(words: [0, 1]))
+        #expect(BigInt(words: [0, 1]) >> Word.bitWidth == BigInt(1))
+        #expect(BigInt(-1) >> Word.bitWidth == BigInt(-1))
+        #expect(BigInt(1) >> Word.bitWidth == BigInt(0))
+        #expect(BigInt(words: [0, Word.max]) >> Word.bitWidth == BigInt(-1))
+        #expect(BigInt(1) >> -Word.bitWidth == BigInt(words: [0, 1]))
 
-        XCTAssertEqual(BigInt(1) &<< BigInt(Word.bitWidth), BigInt(words: [0, 1]))
-        XCTAssertEqual(BigInt(words: [0, 1]) &>> BigInt(Word.bitWidth), BigInt(1))
+        #expect(BigInt(1) &<< BigInt(Word.bitWidth) == BigInt(words: [0, 1]))
+        #expect(BigInt(words: [0, 1]) &>> BigInt(Word.bitWidth) == BigInt(1))
     }
 
-    func testShiftAssignments() {
+    @Test func shiftAssignments() {
 
         var a: BigInt = 1
         a <<= Word.bitWidth
-        XCTAssertEqual(a, BigInt(words: [0, 1]))
+        #expect(a == BigInt(words: [0, 1]))
 
         a = -1
         a <<= Word.bitWidth
-        XCTAssertEqual(a, BigInt(words: [0, Word.max]))
+        #expect(a == BigInt(words: [0, Word.max]))
 
         a = BigInt(words: [0, 1])
         a <<= -Word.bitWidth
-        XCTAssertEqual(a, 1)
+        #expect(a == 1)
 
         a = BigInt(words: [0, 1])
         a >>= Word.bitWidth
-        XCTAssertEqual(a, 1)
+        #expect(a == 1)
 
         a = -1
         a >>= Word.bitWidth
-        XCTAssertEqual(a, -1)
+        #expect(a == -1)
 
         a = 1
         a >>= Word.bitWidth
-        XCTAssertEqual(a, 0)
+        #expect(a == 0)
 
         a = BigInt(words: [0, Word.max])
         a >>= Word.bitWidth
-        XCTAssertEqual(a, BigInt(-1))
+        #expect(a == BigInt(-1))
 
         a = 1
         a >>= -Word.bitWidth
-        XCTAssertEqual(a, BigInt(words: [0, 1]))
+        #expect(a == BigInt(words: [0, 1]))
 
         a = 1
         a &<<= BigInt(Word.bitWidth)
-        XCTAssertEqual(a, BigInt(words: [0, 1]))
+        #expect(a == BigInt(words: [0, 1]))
 
         a = BigInt(words: [0, 1])
         a &>>= BigInt(Word.bitWidth)
-        XCTAssertEqual(a, BigInt(1))
+        #expect(a == BigInt(1))
 
     }
 
-    func testCodable() {
-        func test(_ a: BigInt, file: StaticString = #file, line: UInt = #line) {
+    @Test func codable() {
+        func test(_ a: BigInt) {
             do {
                 let json = try JSONEncoder().encode(a)
                 print(String(data: json, encoding: .utf8)!)
                 let b = try JSONDecoder().decode(BigInt.self, from: json)
-                XCTAssertEqual(a, b, file: file, line: line)
+                #expect(a == b)
             }
             catch let error {
-                XCTFail("Error thrown: \(error.localizedDescription)", file: file, line: line)
+                Issue.record("Error thrown: \(error.localizedDescription)")
             }
         }
         test(0)
@@ -657,21 +641,24 @@ class BigIntTests: XCTestCase {
         test(BigInt(words: [1, 2, 3, 4, 5, 6, 7]))
         test(-BigInt(words: [1, 2, 3, 4, 5, 6, 7]))
 
-        XCTAssertThrowsError(try JSONDecoder().decode(BigUInt.self, from: "[\"*\", 1]".data(using: .utf8)!)) { error in
-            guard let error = error as? DecodingError else { XCTFail("Expected a decoding error"); return }
-            guard case .dataCorrupted(let context) = error else { XCTFail("Expected a dataCorrupted error"); return }
-            XCTAssertEqual(context.debugDescription, "Invalid big integer sign")
+        do {
+            _ = try JSONDecoder().decode(BigUInt.self, from: "[\"*\", 1]".data(using: .utf8)!)
+            Issue.record("Expected a decoding error")
+        } catch {
+            guard let error = error as? DecodingError else { Issue.record("Expected a decoding error"); return }
+            guard case .dataCorrupted(let context) = error else { Issue.record("Expected a dataCorrupted error"); return }
+            #expect(context.debugDescription == "Invalid big integer sign")
         }
     }
 
-    func testDecodableString() {
-        func test(_ a: BigInt, _ v: String? = nil, file: StaticString = #file, line: UInt = #line) {
+    @Test func decodableString() {
+        func test(_ a: BigInt, _ v: String? = nil) {
             do {
                 let json = try JSONEncoder().encode(v ?? a.description)
                 let b = try JSONDecoder().decode(BigInt.self, from: json)
-                XCTAssertEqual(a, b, file: file, line: line)
+                #expect(a == b)
             } catch let error {
-                XCTFail("Error thrown: \(error.localizedDescription)", file: file, line: line)
+                Issue.record("Error thrown: \(error.localizedDescription)")
             }
         }
 
@@ -687,12 +674,15 @@ class BigIntTests: XCTestCase {
         test(-BigInt(1) << 64)
     } 
 
-    func testDecodableStringError() {
+    @Test func decodableStringError() {
         func test(_ v: String, _ m: String) {
-            XCTAssertThrowsError(try JSONDecoder().decode(BigInt.self, from: try! JSONEncoder().encode(v))) { error in
-                guard let error = error as? DecodingError else { XCTFail("Expected a decoding error"); return }
-                guard case .dataCorrupted(let context) = error else { XCTFail("Expected a dataCorrupted error"); return }
-                XCTAssertEqual(m, context.debugDescription)
+            do {
+                _ = try JSONDecoder().decode(BigInt.self, from: try! JSONEncoder().encode(v))
+                Issue.record("Expected a decoding error")
+            } catch {
+                guard let error = error as? DecodingError else { Issue.record("Expected a decoding error"); return }
+                guard case .dataCorrupted(let context) = error else { Issue.record("Expected a dataCorrupted error"); return }
+                #expect(m == context.debugDescription)
             }
         }
 
@@ -702,12 +692,12 @@ class BigIntTests: XCTestCase {
     }
 
     
-    func testConversionToData() {
-        func test(_ b: BigInt, _ d: Array<UInt8>, file: StaticString = #file, line: UInt = #line) {
+    @Test func conversionToData() {
+        func test(_ b: BigInt, _ d: Array<UInt8>) {
             let expected = Data(d)
             let actual = b.serialize()
-            XCTAssertEqual(actual, expected, file: file, line: line)
-            XCTAssertEqual(BigInt(actual), b, file: file, line: line)
+            #expect(actual == expected)
+            #expect(BigInt(actual) == b)
         }
         
         // Positive integers

--- a/Tests/BigIntTests/BigIntTests.swift
+++ b/Tests/BigIntTests/BigIntTests.swift
@@ -513,7 +513,7 @@ import Foundation
             for j in -5 ... 5 {
                 for m in [-7, -5, -3, -2, -1, 1, 2, 3, 5, 7] {
                     guard i != 0 || j >= 0 else { continue }
-                    #expect(BigInt(i).power(BigInt(j), modulus: BigInt(m)) == BigInt(i).power(j).modulus(BigInt(m)), Comment(rawValue: "\(i), \(j), \(m)"))
+                    #expect(BigInt(i).power(BigInt(j), modulus: BigInt(m)) == BigInt(i).power(j).modulus(BigInt(m)), "\(i), \(j), \(m)")
                 }
             }
         }
@@ -545,7 +545,7 @@ import Foundation
                     #expect((base * inverse).modulus(modulus) == 1, "\(base), \(modulus), \(inverse)")
                 }
                 else {
-                    #expect(BigInt(base).greatestCommonDivisor(with: modulus) != BigInt(1), Comment(rawValue: "\(base), \(modulus)"))
+                    #expect(BigInt(base).greatestCommonDivisor(with: modulus) != BigInt(1), "\(base), \(modulus)")
                 }
             }
         }

--- a/Tests/BigIntTests/BigUIntTests.swift
+++ b/Tests/BigIntTests/BigUIntTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2016-2017 Károly Lőrentey.
 //
 
-import XCTest
-import Foundation
+import Testing
 @testable import BigInt
+import Foundation
 
 extension BigUInt.Kind: Equatable {
     public static func ==(left: BigUInt.Kind, right: BigUInt.Kind) -> Bool {
@@ -21,51 +21,33 @@ extension BigUInt.Kind: Equatable {
     }
 }
 
-class BigUIntTests: XCTestCase {
+@Suite struct BigUIntTests {
     typealias Word = BigUInt.Word
 
-    func check(_ value: BigUInt, _ kind: BigUInt.Kind?, _ words: [Word], file: StaticString = #file, line: UInt = #line) {
+    func check(_ value: BigUInt, _ kind: BigUInt.Kind?, _ words: [Word]) {
         if let kind = kind {
-            XCTAssertEqual(
-                value.kind, kind,
-                "Mismatching kind: \(value.kind) vs. \(kind)",
-                file: file, line: line)
+            #expect(value.kind == kind, Comment(rawValue: "Mismatching kind: \(value.kind) vs. \(kind)"))
         }
-        XCTAssertEqual(
-            Array(value.words), words,
-            "Mismatching words: \(value.words) vs. \(words)",
-            file: file, line: line)
-        XCTAssertEqual(
-            value.isZero, words.isEmpty,
-            "Mismatching isZero: \(value.isZero) vs. \(words.isEmpty)",
-            file: file, line: line)
-        XCTAssertEqual(
-            value.count, words.count,
-            "Mismatching count: \(value.count) vs. \(words.count)",
-            file: file, line: line)
+        #expect(Array(value.words) == words, Comment(rawValue: "Mismatching words: \(value.words) vs. \(words)"))
+        #expect(value.isZero == words.isEmpty, Comment(rawValue: "Mismatching isZero: \(value.isZero) vs. \(words.isEmpty)"))
+        #expect(value.count == words.count, Comment(rawValue: "Mismatching count: \(value.count) vs. \(words.count)"))
         for i in 0 ..< words.count {
-            XCTAssertEqual(
-                value[i], words[i],
-                "Mismatching word at index \(i): \(value[i]) vs. \(words[i])",
-                file: file, line: line)
+            #expect(value[i] == words[i], Comment(rawValue: "Mismatching word at index \(i): \(value[i]) vs. \(words[i])"))
         }
         for i in words.count ..< words.count + 10 {
-            XCTAssertEqual(
-                value[i], 0,
-                "Expected 0 word at index \(i), got \(value[i])",
-                file: file, line: line)
+            #expect(value[i] == 0, Comment(rawValue: "Expected 0 word at index \(i), got \(value[i])"))
         }
     }
 
-    func check(_ value: BigUInt?, _ kind: BigUInt.Kind?, _ words: [Word], file: StaticString = #file, line: UInt = #line) {
+    func check(_ value: BigUInt?, _ kind: BigUInt.Kind?, _ words: [Word]) {
         guard let value = value else {
-            XCTFail("Expected non-nil BigUInt", file: file, line: line)
+            Issue.record("Expected non-nil BigUInt")
             return
         }
-        check(value, kind, words, file: file, line: line)
+        check(value, kind, words)
     }
 
-    func testInit_WordBased() {
+    @Test func init_WordBased() {
         check(BigUInt(), .inline(0, 0), [])
 
         check(BigUInt(word: 0), .inline(0, 0), [])
@@ -107,8 +89,8 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(words: IteratorSequence([1, 2, 3, 0, 0, 0, 0].makeIterator())), .array, [1, 2, 3])
     }
 
-    func testInit_BinaryInteger() {
-        XCTAssertNil(BigUInt(exactly: -42))
+    @Test func init_BinaryInteger() {
+        #expect(BigUInt(exactly: -42) == nil)
         check(BigUInt(exactly: 0 as Int), .inline(0, 0), [])
         check(BigUInt(exactly: 42 as Int), .inline(42, 0), [42])
         check(BigUInt(exactly: 43 as UInt), .inline(43, 0), [43])
@@ -119,15 +101,15 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(exactly: BigUInt(words: [1, 2, 3, 4])), .array, [1, 2, 3, 4])
     }
 
-    func testInit_FloatingPoint() {
+    @Test func init_FloatingPoint() {
         check(BigUInt(exactly: -0.0 as Float), nil, [])
         check(BigUInt(exactly: -0.0 as Double), nil, [])
 
-        XCTAssertNil(BigUInt(exactly: -42.0 as Float))
-        XCTAssertNil(BigUInt(exactly: -42.0 as Double))
+        #expect(BigUInt(exactly: -42.0 as Float) == nil)
+        #expect(BigUInt(exactly: -42.0 as Double) == nil)
 
-        XCTAssertNil(BigUInt(exactly: 42.5 as Float))
-        XCTAssertNil(BigUInt(exactly: 42.5 as Double))
+        #expect(BigUInt(exactly: 42.5 as Float) == nil)
+        #expect(BigUInt(exactly: 42.5 as Double) == nil)
 
         check(BigUInt(exactly: 100 as Float), nil, [100])
         check(BigUInt(exactly: 100 as Double), nil, [100])
@@ -138,14 +120,14 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(exactly: Double.greatestFiniteMagnitude), nil,
               convertWords([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFFFFFFFFFFFFF800]))
 
-        XCTAssertNil(BigUInt(exactly: Float.leastNormalMagnitude))
-        XCTAssertNil(BigUInt(exactly: Double.leastNormalMagnitude))
+        #expect(BigUInt(exactly: Float.leastNormalMagnitude) == nil)
+        #expect(BigUInt(exactly: Double.leastNormalMagnitude) == nil)
 
-        XCTAssertNil(BigUInt(exactly: Float.infinity))
-        XCTAssertNil(BigUInt(exactly: Double.infinity))
+        #expect(BigUInt(exactly: Float.infinity) == nil)
+        #expect(BigUInt(exactly: Double.infinity) == nil)
 
-        XCTAssertNil(BigUInt(exactly: Float.nan))
-        XCTAssertNil(BigUInt(exactly: Double.nan))
+        #expect(BigUInt(exactly: Float.nan) == nil)
+        #expect(BigUInt(exactly: Double.nan) == nil)
 
         check(BigUInt(0 as Float), nil, [])
         check(BigUInt(Float.leastNonzeroMagnitude), nil, [])
@@ -157,50 +139,49 @@ class BigUIntTests: XCTestCase {
               nil, [0, 0, 1])
     }
 
-    func testInit_Decimal() throws {
-        XCTAssertEqual(BigUInt(exactly: Decimal(0)), 0)
-        XCTAssertEqual(BigUInt(exactly: Decimal(Double.nan)), nil)
-        XCTAssertEqual(BigUInt(exactly: Decimal(10)), 10)
-        XCTAssertEqual(BigUInt(exactly: Decimal(1000)), 1000)
-        XCTAssertEqual(BigUInt(exactly: Decimal(1000.1)), nil)
-        XCTAssertEqual(BigUInt(exactly: Decimal(1000.9)), nil)
-        XCTAssertEqual(BigUInt(exactly: Decimal(1001.5)), nil)
-        XCTAssertEqual(BigUInt(exactly: Decimal(UInt.max) + 5), "18446744073709551620")
-        XCTAssertEqual(BigUInt(exactly: (Decimal(UInt.max) + 5.5)), nil)
-        XCTAssertEqual(BigUInt(exactly: Decimal.greatestFiniteMagnitude),
-                       "3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
-        XCTAssertEqual(BigUInt(truncating: Decimal(0)), 0)
-        XCTAssertEqual(BigUInt(truncating: Decimal(Double.nan)), nil)
-        XCTAssertEqual(BigUInt(truncating: Decimal(10)), 10)
-        XCTAssertEqual(BigUInt(truncating: Decimal(1000)), 1000)
-        XCTAssertEqual(BigUInt(truncating: Decimal(1000.1)), 1000)
-        XCTAssertEqual(BigUInt(truncating: Decimal(1000.9)), 1000)
-        XCTAssertEqual(BigUInt(truncating: Decimal(1001.5)), 1001)
-        XCTAssertEqual(BigUInt(truncating: Decimal(UInt.max) + 5), "18446744073709551620")
-        XCTAssertEqual(BigUInt(truncating: (Decimal(UInt.max) + 5.5)), "18446744073709551620")
+    @Test func init_Decimal() throws {
+        #expect(BigUInt(exactly: Decimal(0)) == 0)
+        #expect(BigUInt(exactly: Decimal(Double.nan)) == nil)
+        #expect(BigUInt(exactly: Decimal(10)) == 10)
+        #expect(BigUInt(exactly: Decimal(1000)) == 1000)
+        #expect(BigUInt(exactly: Decimal(1000.1)) == nil)
+        #expect(BigUInt(exactly: Decimal(1000.9)) == nil)
+        #expect(BigUInt(exactly: Decimal(1001.5)) == nil)
+        #expect(BigUInt(exactly: Decimal(UInt.max) + 5) == "18446744073709551620")
+        #expect(BigUInt(exactly: (Decimal(UInt.max) + 5.5)) == nil)
+        #expect(BigUInt(exactly: Decimal.greatestFiniteMagnitude) == "3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+        #expect(BigUInt(truncating: Decimal(0)) == 0)
+        #expect(BigUInt(truncating: Decimal(Double.nan)) == nil)
+        #expect(BigUInt(truncating: Decimal(10)) == 10)
+        #expect(BigUInt(truncating: Decimal(1000)) == 1000)
+        #expect(BigUInt(truncating: Decimal(1000.1)) == 1000)
+        #expect(BigUInt(truncating: Decimal(1000.9)) == 1000)
+        #expect(BigUInt(truncating: Decimal(1001.5)) == 1001)
+        #expect(BigUInt(truncating: Decimal(UInt.max) + 5) == "18446744073709551620")
+        #expect(BigUInt(truncating: (Decimal(UInt.max) + 5.5)) == "18446744073709551620")
 
-        XCTAssertEqual(BigUInt(exactly: -Decimal(10)), nil)
-        XCTAssertEqual(BigUInt(exactly: -Decimal(1000)), nil)
-        XCTAssertEqual(BigUInt(exactly: -Decimal(1000.1)), nil)
-        XCTAssertEqual(BigUInt(exactly: -Decimal(1000.9)), nil)
-        XCTAssertEqual(BigUInt(exactly: -Decimal(1001.5)), nil)
-        XCTAssertEqual(BigUInt(exactly: -Decimal(UInt.max) + 5), nil)
-        XCTAssertEqual(BigUInt(exactly: -(Decimal(UInt.max) + 5.5)), nil)
-        XCTAssertEqual(BigUInt(exactly: Decimal.leastFiniteMagnitude), nil)
-        XCTAssertEqual(BigUInt(truncating: -Decimal(10)), nil)
-        XCTAssertEqual(BigUInt(truncating: -Decimal(1000)), nil)
-        XCTAssertEqual(BigUInt(truncating: -Decimal(1000.1)), nil)
-        XCTAssertEqual(BigUInt(truncating: -Decimal(1000.9)), nil)
-        XCTAssertEqual(BigUInt(truncating: -Decimal(1001.5)), nil)
-        XCTAssertEqual(BigUInt(truncating: -Decimal(UInt.max) + 5), nil)
-        XCTAssertEqual(BigUInt(truncating: -(Decimal(UInt.max) + 5.5)), nil)
+        #expect(BigUInt(exactly: -Decimal(10)) == nil)
+        #expect(BigUInt(exactly: -Decimal(1000)) == nil)
+        #expect(BigUInt(exactly: -Decimal(1000.1)) == nil)
+        #expect(BigUInt(exactly: -Decimal(1000.9)) == nil)
+        #expect(BigUInt(exactly: -Decimal(1001.5)) == nil)
+        #expect(BigUInt(exactly: -Decimal(UInt.max) + 5) == nil)
+        #expect(BigUInt(exactly: -(Decimal(UInt.max) + 5.5)) == nil)
+        #expect(BigUInt(exactly: Decimal.leastFiniteMagnitude) == nil)
+        #expect(BigUInt(truncating: -Decimal(10)) == nil)
+        #expect(BigUInt(truncating: -Decimal(1000)) == nil)
+        #expect(BigUInt(truncating: -Decimal(1000.1)) == nil)
+        #expect(BigUInt(truncating: -Decimal(1000.9)) == nil)
+        #expect(BigUInt(truncating: -Decimal(1001.5)) == nil)
+        #expect(BigUInt(truncating: -Decimal(UInt.max) + 5) == nil)
+        #expect(BigUInt(truncating: -(Decimal(UInt.max) + 5.5)) == nil)
     }
 
-    func testInit_Buffer() {
-        func test(_ b: BigUInt, _ d: Array<UInt8>, file: StaticString = #file, line: UInt = #line) {
+    @Test func init_Buffer() {
+        func test(_ b: BigUInt, _ d: Array<UInt8>) {
             d.withUnsafeBytes { buffer in
                 let initialized = BigUInt(buffer)
-                XCTAssertEqual(initialized, b, file: file, line: line)
+                #expect(initialized == b)
             }
         }
         
@@ -209,14 +190,14 @@ class BigUIntTests: XCTestCase {
         test(BigUInt(1), [0x01])
         test(BigUInt(2), [0x02])
         test(BigUInt(0x0102030405060708), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
-        test(BigUInt(0x01) << 64 + BigUInt(0x0203040506070809), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 09])
+        test(BigUInt(0x01) << 64 + BigUInt(0x0203040506070809), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])
     }
 
-    func testConversionToFloatingPoint() {
-        func test<F: BinaryFloatingPoint>(_ a: BigUInt, _ b: F, file: StaticString = #file, line: UInt = #line)
+    @Test func conversionToFloatingPoint() {
+        func test<F: BinaryFloatingPoint>(_ a: BigUInt, _ b: F)
         where F.RawExponent: FixedWidthInteger, F.RawSignificand: FixedWidthInteger {
             let f = F(a)
-            XCTAssertEqual(f, b, file: file, line: line)
+            #expect(f == b)
         }
 
         for i in 0 ..< 100 {
@@ -265,14 +246,14 @@ class BigUIntTests: XCTestCase {
         test(BigUInt(0x8000028000000000 as UInt64), 0x800002p40 as Float)
         test(BigUInt(0x800002FFFFFFFFFF as UInt64), 0x800002p40 as Float)
 
-        XCTAssertEqual(Decimal(BigUInt(0)), 0)
-        XCTAssertEqual(Decimal(BigUInt(20)), 20)
-        XCTAssertEqual(Decimal(BigUInt(123456789)), 123456789)
-        XCTAssertEqual(Decimal(BigUInt(exactly: Decimal.greatestFiniteMagnitude)!), .greatestFiniteMagnitude)
-        XCTAssertEqual(Decimal(BigUInt(exactly: Decimal.greatestFiniteMagnitude)! * 2), .greatestFiniteMagnitude)
+        #expect(Decimal(BigUInt(0)) == 0)
+        #expect(Decimal(BigUInt(20)) == 20)
+        #expect(Decimal(BigUInt(123456789)) == 123456789)
+        #expect(Decimal(BigUInt(exactly: Decimal.greatestFiniteMagnitude)!) == .greatestFiniteMagnitude)
+        #expect(Decimal(BigUInt(exactly: Decimal.greatestFiniteMagnitude)! * 2) == .greatestFiniteMagnitude)
     }
 
-    func testInit_Misc() {
+    @Test func init_Misc() {
         check(BigUInt(0), .inline(0, 0), [])
         check(BigUInt(42), .inline(42, 0), [42])
         check(BigUInt(BigUInt(words: [1, 2, 3])), .array, [1, 2, 3])
@@ -287,7 +268,7 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(clamping: Word.max), .inline(Word.max, 0), [Word.max])
     }
 
-    func testEnsureArray() {
+    @Test func ensureArray() {
         var a = BigUInt()
         a.ensureArray()
         check(a, .array, [])
@@ -309,59 +290,59 @@ class BigUIntTests: XCTestCase {
         check(a, .array, [2, 3, 4, 5])
     }
 
-    func testCapacity() {
-        XCTAssertEqual(BigUInt(low: 1, high: 2).capacity, 0)
-        XCTAssertEqual(BigUInt(words: 1 ..< 10).extract(2 ..< 5).capacity, 0)
+    @Test func capacity() {
+        #expect(BigUInt(low: 1, high: 2).capacity == 0)
+        #expect(BigUInt(words: 1 ..< 10).extract(2 ..< 5).capacity == 0)
         var words: [Word] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         words.reserveCapacity(100)
-        XCTAssertGreaterThanOrEqual(BigUInt(words: words).capacity, 100)
+        #expect(BigUInt(words: words).capacity >= 100)
     }
 
-    func testReserveCapacity() {
+    @Test func reserveCapacity() {
         var a = BigUInt()
         a.reserveCapacity(100)
         check(a, .array, [])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
 
         a = BigUInt(word: 1)
         a.reserveCapacity(100)
         check(a, .array, [1])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
 
         a = BigUInt(low: 1, high: 2)
         a.reserveCapacity(100)
         check(a, .array, [1, 2])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
 
         a = BigUInt(words: [1, 2, 3, 4])
         a.reserveCapacity(100)
         check(a, .array, [1, 2, 3, 4])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
 
         a = BigUInt(words: [1, 2, 3, 4, 5, 6], from: 1, to: 5)
         a.reserveCapacity(100)
         check(a, .array, [2, 3, 4, 5])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
     }
 
-    func testLoad() {
+    @Test func load() {
         var a: BigUInt = 0
         a.reserveCapacity(100)
 
         a.load(BigUInt(low: 1, high: 2))
         check(a, .array, [1, 2])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
 
         a.load(BigUInt(words: [1, 2, 3, 4, 5, 6]))
         check(a, .array, [1, 2, 3, 4, 5, 6])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
 
         a.clear()
         check(a, .array, [])
-        XCTAssertGreaterThanOrEqual(a.capacity, 100)
+        #expect(a.capacity >= 100)
     }
 
-    func testInitFromLiterals() {
+    @Test func initFromLiterals() {
         check(0, .inline(0, 0), [])
         check(42, .inline(42, 0), [42])
         check("42", .inline(42, 0), [42])
@@ -375,23 +356,23 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(extendedGraphemeClusterLiteral: "4"), .inline(4, 0), [4])
     }
 
-    func testSubscriptingGetter() {
+    @Test func subscriptingGetter() {
         let a = BigUInt(words: [1, 2])
-        XCTAssertEqual(a[0], 1)
-        XCTAssertEqual(a[1], 2)
-        XCTAssertEqual(a[2], 0)
-        XCTAssertEqual(a[3], 0)
-        XCTAssertEqual(a[10000], 0)
+        #expect(a[0] == 1)
+        #expect(a[1] == 2)
+        #expect(a[2] == 0)
+        #expect(a[3] == 0)
+        #expect(a[10000] == 0)
 
         let b = BigUInt(low: 1, high: 2)
-        XCTAssertEqual(b[0], 1)
-        XCTAssertEqual(b[1], 2)
-        XCTAssertEqual(b[2], 0)
-        XCTAssertEqual(b[3], 0)
-        XCTAssertEqual(b[10000], 0)
+        #expect(b[0] == 1)
+        #expect(b[1] == 2)
+        #expect(b[2] == 0)
+        #expect(b[3] == 0)
+        #expect(b[10000] == 0)
     }
 
-    func testSubscriptingSetter() {
+    @Test func subscriptingSetter() {
         var a = BigUInt()
 
         check(a, .inline(0, 0), [])
@@ -411,7 +392,7 @@ class BigUIntTests: XCTestCase {
         check(a, .array, [1, 2, 42, 4])
     }
 
-    func testSlice() {
+    @Test func slice() {
         let a = BigUInt(words: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         check(a.extract(3 ..< 6), .slice(from: 3, to: 6), [3, 4, 5])
         check(a.extract(3 ..< 5), .inline(3, 4), [3, 4])
@@ -436,7 +417,7 @@ class BigUIntTests: XCTestCase {
         check(c.extract(4 ..< 7), .inline(2, 0), [2])
 
         let d = c.extract(3 ..< 14)
-                                        // 0  1  2  3  4  5  6  7  8  9 10
+                                        //  0  1  2  3  4  5  6  7  8  9 10
         check(d, .slice(from: 3, to: 14), [0, 2, 0, 0, 0, 3, 4, 5, 0, 0, 6])
         check(d.extract(1 ..< 5), .inline(2, 0), [2])
         check(d.extract(0 ..< 3), .inline(0, 2), [0, 2])
@@ -446,23 +427,23 @@ class BigUIntTests: XCTestCase {
         check(d.extract(11 ..< 1000), .inline(0, 0), [])
     }
 
-    func testSigns() {
-        XCTAssertFalse(BigUInt.isSigned)
+    @Test func signs_() {
+        #expect(!BigUInt.isSigned)
 
-        XCTAssertEqual(BigUInt().signum(), 0)
-        XCTAssertEqual(BigUInt(words: []).signum(), 0)
-        XCTAssertEqual(BigUInt(words: [0, 1, 2]).signum(), 1)
-        XCTAssertEqual(BigUInt(word: 42).signum(), 1)
+        #expect(BigUInt().signum() == 0)
+        #expect(BigUInt(words: []).signum() == 0)
+        #expect(BigUInt(words: [0, 1, 2]).signum() == 1)
+        #expect(BigUInt(word: 42).signum() == 1)
     }
 
-    func testBits() {
+    @Test func bits() {
         let indices: Set<Int> = [0, 13, 59, 64, 79, 130]
         var value: BigUInt = 0
         for i in indices {
             value[bitAt: i] = true
         }
         for i in 0 ..< 300 {
-            XCTAssertEqual(value[bitAt: i], indices.contains(i))
+            #expect(value[bitAt: i] == indices.contains(i))
         }
         check(value, nil, convertWords([0x0800000000002001, 0x8001, 0x04]))
         for i in indices {
@@ -471,14 +452,14 @@ class BigUIntTests: XCTestCase {
         check(value, nil, [])
     }
 
-    func testStrideableRequirements() {
-        XCTAssertEqual(BigUInt(10), BigUInt(4).advanced(by: BigInt(6)))
-        XCTAssertEqual(BigUInt(4), BigUInt(10).advanced(by: BigInt(-6)))
-        XCTAssertEqual(BigInt(6), BigUInt(4).distance(to: 10))
-        XCTAssertEqual(BigInt(-6), BigUInt(10).distance(to: 4))
+    @Test func strideableRequirements() {
+        #expect(BigUInt(10) == BigUInt(4).advanced(by: BigInt(6)))
+        #expect(BigUInt(4) == BigUInt(10).advanced(by: BigInt(-6)))
+        #expect(BigInt(6) == BigUInt(4).distance(to: 10))
+        #expect(BigInt(-6) == BigUInt(10).distance(to: 4))
     }
 
-    func testRightShift_ByWord() {
+    @Test func rightShift_ByWord() {
         var a = BigUInt()
         a.shiftRight(byWords: 1)
         check(a, .inline(0, 0), [])
@@ -543,7 +524,7 @@ class BigUIntTests: XCTestCase {
         check(a, .inline(0, 0), [])
     }
 
-    func testLeftShift_ByWord() {
+    @Test func leftShift_ByWord() {
         var a = BigUInt()
         a.shiftLeft(byWords: 1)
         check(a, .inline(0, 0), [])
@@ -585,13 +566,13 @@ class BigUIntTests: XCTestCase {
         check(a, .array, [0, 0, 0, 2, 3, 4, 5])
     }
 
-    func testSplit() {
+    @Test func split_() {
         let a = BigUInt(words: [0, 1, 2, 3])
-        XCTAssertEqual(a.split.low, BigUInt(words: [0, 1]))
-        XCTAssertEqual(a.split.high, BigUInt(words: [2, 3]))
+        #expect(a.split.low == BigUInt(words: [0, 1]))
+        #expect(a.split.high == BigUInt(words: [2, 3]))
     }
 
-    func testLowHigh() {
+    @Test func lowHigh() {
         let a = BigUInt(words: [0, 1, 2, 3])
         check(a.low, .inline(0, 1), [0, 1])
         check(a.high, .inline(2, 3), [2, 3])
@@ -626,20 +607,20 @@ class BigUIntTests: XCTestCase {
         check(bhhh, .inline(4, 0), [4])
     }
 
-    func testComparison() {
-        XCTAssertEqual(BigUInt(words: [1, 2, 3]), BigUInt(words: [1, 2, 3]))
-        XCTAssertNotEqual(BigUInt(words: [1, 2]), BigUInt(words: [1, 2, 3]))
-        XCTAssertNotEqual(BigUInt(words: [1, 2, 3]), BigUInt(words: [1, 3, 3]))
-        XCTAssertEqual(BigUInt(words: [1, 2, 3, 4, 5, 6]).low.high, BigUInt(words: [3]))
+    @Test func comparison() {
+        #expect(BigUInt(words: [1, 2, 3]) == BigUInt(words: [1, 2, 3]))
+        #expect(BigUInt(words: [1, 2]) != BigUInt(words: [1, 2, 3]))
+        #expect(BigUInt(words: [1, 2, 3]) != BigUInt(words: [1, 3, 3]))
+        #expect(BigUInt(words: [1, 2, 3, 4, 5, 6]).low.high == BigUInt(words: [3]))
 
-        XCTAssertTrue(BigUInt(words: [1, 2]) < BigUInt(words: [1, 2, 3]))
-        XCTAssertTrue(BigUInt(words: [1, 2, 2]) < BigUInt(words: [1, 2, 3]))
-        XCTAssertFalse(BigUInt(words: [1, 2, 3]) < BigUInt(words: [1, 2, 3]))
-        XCTAssertTrue(BigUInt(words: [3, 3]) < BigUInt(words: [1, 2, 3, 4, 5, 6]).extract(2 ..< 4))
-        XCTAssertTrue(BigUInt(words: [1, 2, 3, 4, 5, 6]).low.high < BigUInt(words: [3, 5]))
+        #expect(BigUInt(words: [1, 2]) < BigUInt(words: [1, 2, 3]))
+        #expect(BigUInt(words: [1, 2, 2]) < BigUInt(words: [1, 2, 3]))
+        #expect(BigUInt(words: [1, 2, 3]) >= BigUInt(words: [1, 2, 3]))
+        #expect(BigUInt(words: [3, 3]) < BigUInt(words: [1, 2, 3, 4, 5, 6]).extract(2 ..< 4))
+        #expect(BigUInt(words: [1, 2, 3, 4, 5, 6]).low.high < BigUInt(words: [3, 5]))
     }
 
-    func testHashing() {
+    @Test func hashing_() {
         var hashes: [Int] = []
         hashes.append(BigUInt(words: []).hashValue)
         hashes.append(BigUInt(words: [1]).hashValue)
@@ -655,15 +636,15 @@ class BigUIntTests: XCTestCase {
         hashes.append(BigUInt(words: [Word.max, Word.max]).hashValue)
         hashes.append(BigUInt(words: [Word.max, Word.max, Word.max]).hashValue)
         hashes.append(BigUInt(words: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).hashValue)
-        XCTAssertEqual(hashes.count, Set(hashes).count)
+        #expect(hashes.count == Set(hashes).count)
     }
 
-    func checkData(_ bytes: [UInt8], _ value: BigUInt, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(BigUInt(Data(bytes)), value, file: file, line: line)
-        XCTAssertEqual(bytes.withUnsafeBytes { buffer in BigUInt(buffer) }, value, file: file, line: line)
+    func checkData(_ bytes: [UInt8], _ value: BigUInt) {
+        #expect(BigUInt(Data(bytes)) == value)
+        #expect(bytes.withUnsafeBytes { buffer in BigUInt(buffer) } == value)
     }
 
-    func testConversionFromBytes() {
+    @Test func conversionFromBytes() {
         checkData([], 0)
         checkData([0], 0)
         checkData([0, 0, 0, 0, 0, 0, 0, 0], 0)
@@ -683,12 +664,12 @@ class BigUIntTests: XCTestCase {
                   ((BigUInt(1) << 128) as BigUInt) + BigUInt(0x0203040506070809) << 64 + BigUInt(0x0A0B0C0D0E0F1011))
     }
 
-    func testConversionToData() {
-        func test(_ b: BigUInt, _ d: Array<UInt8>, file: StaticString = #file, line: UInt = #line) {
+    @Test func conversionToData_() {
+        func test(_ b: BigUInt, _ d: Array<UInt8>) {
             let expected = Data(d)
             let actual = b.serialize()
-            XCTAssertEqual(actual, expected, file: file, line: line)
-            XCTAssertEqual(BigUInt(actual), b, file: file, line: line)
+            #expect(actual == expected)
+            #expect(BigUInt(actual) == b)
         }
 
         test(BigUInt(), [])
@@ -699,16 +680,16 @@ class BigUIntTests: XCTestCase {
         test(BigUInt(0x01) << 64 + BigUInt(0x0203040506070809), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09])
     }
 
-    func testCodable() {
-        func test(_ a: BigUInt, file: StaticString = #file, line: UInt = #line) {
+    @Test func codable_() {
+        func test(_ a: BigUInt) {
             do {
                 let json = try JSONEncoder().encode(a)
                 print(String(data: json, encoding: .utf8)!)
                 let b = try JSONDecoder().decode(BigUInt.self, from: json)
-                XCTAssertEqual(a, b, file: file, line: line)
+                #expect(a == b)
             }
             catch let error {
-                XCTFail("Error thrown: \(error.localizedDescription)", file: file, line: line)
+                Issue.record("Error thrown: \(error.localizedDescription)")
             }
         }
         test(0)
@@ -717,22 +698,28 @@ class BigUIntTests: XCTestCase {
         test(BigUInt(1) << 64)
         test(BigUInt(words: [1, 2, 3, 4, 5, 6, 7]))
 
-        XCTAssertThrowsError(try JSONDecoder().decode(BigUInt.self, from: "[\"*\", 1]".data(using: .utf8)!)) { error in
-            guard let error = error as? DecodingError else { XCTFail("Expected a decoding error"); return }
-            guard case .dataCorrupted(let context) = error else { XCTFail("Expected a dataCorrupted error"); return }
-            XCTAssertEqual(context.debugDescription, "Invalid big integer sign")
+        do {
+            _ = try JSONDecoder().decode(BigUInt.self, from: "[\"*\", 1]".data(using: .utf8)!)
+            Issue.record("Expected a decoding error")
+        } catch {
+            guard let error = error as? DecodingError else { Issue.record("Expected a decoding error"); return }
+            guard case .dataCorrupted(let context) = error else { Issue.record("Expected a dataCorrupted error"); return }
+            #expect(context.debugDescription == "Invalid big integer sign")
         }
-        XCTAssertThrowsError(try JSONDecoder().decode(BigUInt.self, from: "[\"-\", 1]".data(using: .utf8)!)) { error in
-            guard let error = error as? DecodingError else { XCTFail("Expected a decoding error"); return }
-            guard case .dataCorrupted(let context) = error else { XCTFail("Expected a dataCorrupted error"); return }
-            XCTAssertEqual(context.debugDescription, "BigUInt cannot hold a negative value")
+        do {
+            _ = try JSONDecoder().decode(BigUInt.self, from: "[\"-\", 1]".data(using: .utf8)!)
+            Issue.record("Expected a decoding error")
+        } catch {
+            guard let error = error as? DecodingError else { Issue.record("Expected a decoding error"); return }
+            guard case .dataCorrupted(let context) = error else { Issue.record("Expected a dataCorrupted error"); return }
+            #expect(context.debugDescription == "BigUInt cannot hold a negative value")
         }
     }
 
-    func testAddition() {
-        XCTAssertEqual(BigUInt(0) + BigUInt(0), BigUInt(0))
-        XCTAssertEqual(BigUInt(0) + BigUInt(Word.max), BigUInt(Word.max))
-        XCTAssertEqual(BigUInt(Word.max) + BigUInt(1), BigUInt(words: [0, 1]))
+    @Test func addition_() {
+        #expect(BigUInt(0) + BigUInt(0) == BigUInt(0))
+        #expect(BigUInt(0) + BigUInt(Word.max) == BigUInt(Word.max))
+        #expect(BigUInt(Word.max) + BigUInt(1) == BigUInt(words: [0, 1]))
 
         check(BigUInt(3) + BigUInt(42), .inline(45, 0), [45])
         check(BigUInt(3) + BigUInt(42), .inline(45, 0), [45])
@@ -750,7 +737,7 @@ class BigUIntTests: XCTestCase {
         check(b, .array, [0, 3, Word.max])
     }
 
-    func testShiftedAddition() {
+    @Test func shiftedAddition() {
         var b = BigUInt()
         b.add(1, shiftedBy: 1)
         check(b, .inline(0, 1), [0, 1])
@@ -762,17 +749,17 @@ class BigUIntTests: XCTestCase {
         check(b, .array, [0, 0, 1, 2])
     }
 
-    func testSubtraction() {
+    @Test func subtraction_() {
         var a1 = BigUInt(words: [1, 2, 3, 4])
-        XCTAssertEqual(false, a1.subtractWordReportingOverflow(3, shiftedBy: 1))
+        #expect(false == a1.subtractWordReportingOverflow(3, shiftedBy: 1))
         check(a1, .array, [1, Word.max, 2, 4])
 
         let (diff, overflow) = BigUInt(words: [1, 2, 3, 4]).subtractingWordReportingOverflow(2)
-        XCTAssertEqual(false, overflow)
+        #expect(false == overflow)
         check(diff, .array, [Word.max, 1, 3, 4])
 
         var a2 = BigUInt(words: [1, 2, 3, 4])
-        XCTAssertEqual(true, a2.subtractWordReportingOverflow(5, shiftedBy: 3))
+        #expect(true == a2.subtractWordReportingOverflow(5, shiftedBy: 3))
         check(a2, .array, [1, 2, 3, Word.max])
 
         var a3 = BigUInt(words: [1, 2, 3, 4])
@@ -791,11 +778,11 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(0) - BigUInt(0), .inline(0, 0), [])
 
         var b = BigUInt(words: [1, 2, 3, 4])
-        XCTAssertEqual(false, b.subtractReportingOverflow(BigUInt(words: [0, 1, 1, 1])))
+        #expect(false == b.subtractReportingOverflow(BigUInt(words: [0, 1, 1, 1])))
         check(b, .array, [1, 1, 2, 3])
 
         let b1 = BigUInt(words: [1, 1, 2, 3]).subtractingReportingOverflow(BigUInt(words: [1, 1, 3, 3]))
-        XCTAssertEqual(true, b1.overflow)
+        #expect(true == b1.overflow)
         check(b1.partialValue, .array, [0, 0, Word.max, Word.max])
 
         let b2 = BigUInt(words: [0, 0, 1]) - BigUInt(words: [1])
@@ -808,7 +795,7 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(42) - BigUInt(23), .inline(19, 0), [19])
     }
 
-    func testMultiplyByWord() {
+    @Test func multiplyByWord() {
         check(BigUInt(words: [1, 2, 3, 4]).multiplied(byWord: 0), .inline(0, 0), [])
         check(BigUInt(words: [1, 2, 3, 4]).multiplied(byWord: 2), .array, [2, 4, 6, 8])
 
@@ -832,76 +819,50 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(low: 1, high: 2).multiplied(byWord: 3), .inline(3, 6), [3, 6])
     }
 
-    func testMultiplication() {
+    @Test func multiplication_() {
         func test() {
             check(BigUInt(low: 1, high: 1) * BigUInt(word: 3), .inline(3, 3), [3, 3])
             check(BigUInt(word: 4) * BigUInt(low: 1, high: 2), .inline(4, 8), [4, 8])
 
-            XCTAssertEqual(
-                BigUInt(words: [1, 2, 3, 4]) * BigUInt(),
-                BigUInt())
-            XCTAssertEqual(
-                BigUInt() * BigUInt(words: [1, 2, 3, 4]),
-                BigUInt())
-            XCTAssertEqual(
-                BigUInt(words: [1, 2, 3, 4]) * BigUInt(words: [2]),
-                BigUInt(words: [2, 4, 6, 8]))
-            XCTAssertEqual(
-                BigUInt(words: [1, 2, 3, 4]).multiplied(by: BigUInt(words: [2])),
-                BigUInt(words: [2, 4, 6, 8]))
-            XCTAssertEqual(
-                BigUInt(words: [2]) * BigUInt(words: [1, 2, 3, 4]),
-                BigUInt(words: [2, 4, 6, 8]))
-            XCTAssertEqual(
-                BigUInt(words: [1, 2, 3, 4]) * BigUInt(words: [0, 1]),
-                BigUInt(words: [0, 1, 2, 3, 4]))
-            XCTAssertEqual(
-                BigUInt(words: [0, 1]) * BigUInt(words: [1, 2, 3, 4]),
-                BigUInt(words: [0, 1, 2, 3, 4]))
-            XCTAssertEqual(
-                BigUInt(words: [4, 3, 2, 1]) * BigUInt(words: [1, 2, 3, 4]),
-                BigUInt(words: [4, 11, 20, 30, 20, 11, 4]))
+            #expect(BigUInt(words: [1, 2, 3, 4]) * BigUInt() == BigUInt())
+            #expect(BigUInt() * BigUInt(words: [1, 2, 3, 4]) == BigUInt())
+            #expect(BigUInt(words: [1, 2, 3, 4]) * BigUInt(words: [2]) == BigUInt(words: [2, 4, 6, 8]))
+            #expect(BigUInt(words: [1, 2, 3, 4]).multiplied(by: BigUInt(words: [2])) == BigUInt(words: [2, 4, 6, 8]))
+            #expect(BigUInt(words: [2]) * BigUInt(words: [1, 2, 3, 4]) == BigUInt(words: [2, 4, 6, 8]))
+            #expect(BigUInt(words: [1, 2, 3, 4]) * BigUInt(words: [0, 1]) == BigUInt(words: [0, 1, 2, 3, 4]))
+            #expect(BigUInt(words: [0, 1]) * BigUInt(words: [1, 2, 3, 4]) == BigUInt(words: [0, 1, 2, 3, 4]))
+            #expect(BigUInt(words: [4, 3, 2, 1]) * BigUInt(words: [1, 2, 3, 4]) == BigUInt(words: [4, 11, 20, 30, 20, 11, 4]))
             // 999 * 99 = 98901
-            XCTAssertEqual(
-                BigUInt(words: [Word.max, Word.max, Word.max]) * BigUInt(words: [Word.max, Word.max]),
-                BigUInt(words: [1, 0, Word.max, Word.max - 1, Word.max]))
-            XCTAssertEqual(
-                BigUInt(words: [1, 2]) * BigUInt(words: [2, 1]),
-                BigUInt(words: [2, 5, 2]))
+            #expect(BigUInt(words: [Word.max, Word.max, Word.max]) * BigUInt(words: [Word.max, Word.max]) == BigUInt(words: [1, 0, Word.max, Word.max - 1, Word.max]))
+            #expect(BigUInt(words: [1, 2]) * BigUInt(words: [2, 1]) == BigUInt(words: [2, 5, 2]))
 
             var b = BigUInt("2637AB28", radix: 16)!
             b *= BigUInt("164B", radix: 16)!
-            XCTAssertEqual(b, BigUInt("353FB0494B8", radix: 16))
+            #expect(b == BigUInt("353FB0494B8", radix: 16))
 
-            XCTAssertEqual(BigUInt("16B60", radix: 16)! * BigUInt("33E28", radix: 16)!, BigUInt("49A5A0700", radix: 16)!)
+            #expect(BigUInt("16B60", radix: 16)! * BigUInt("33E28", radix: 16)! == BigUInt("49A5A0700", radix: 16)!)
         }
 
         test()
-        // Disable brute force multiplication.
-//        let limit = BigUInt.directMultiplicationLimit
-//        BigUInt.directMultiplicationLimit = 0
-//        defer { BigUInt.directMultiplicationLimit = limit }
-//
-//        test()
     }
 
-    func testDivision() {
-        func test(_ a: [Word], _ b: [Word], file: StaticString = #file, line: UInt = #line) {
+    @Test func division_() {
+        func test(_ a: [Word], _ b: [Word]) {
             let x = BigUInt(words: a)
             let y = BigUInt(words: b)
             let (div, mod) = x.quotientAndRemainder(dividingBy: y)
             if mod >= y {
-                XCTFail("x:\(x) = div:\(div) * y:\(y) + mod:\(mod)", file: file, line: line)
+                Issue.record("x:\(x) = div:\(div) * y:\(y) + mod:\(mod)")
             }
             if div * y + mod != x {
-                XCTFail("x:\(x) = div:\(div) * y:\(y) + mod:\(mod)", file: file, line: line)
+                Issue.record("x:\(x) = div:\(div) * y:\(y) + mod:\(mod)")
             }
 
             let shift = y.leadingZeroBitCount
             let norm = y << shift
             var rem = x
             rem.formRemainder(dividingBy: norm, normalizedBy: shift)
-            XCTAssertEqual(rem, mod, file: file, line: line)
+            #expect(rem == mod)
         }
 
         // These cases exercise all code paths in the division when Word is UInt8 or UInt64.
@@ -925,33 +886,18 @@ class BigUIntTests: XCTestCase {
         test([0, Word.max - 1, Word.max / 2 + 1], [Word.max, Word.max / 2 + 1])
         test([0, 0, 0x41 << Word(Word.bitWidth - 8)], [Word.max, 1 << Word(Word.bitWidth - 1)])
 
-        XCTAssertEqual(BigUInt(328) / BigUInt(21), BigUInt(15))
-        XCTAssertEqual(BigUInt(328) % BigUInt(21), BigUInt(13))
+        #expect(BigUInt(328) / BigUInt(21) == BigUInt(15))
+        #expect(BigUInt(328) % BigUInt(21) == BigUInt(13))
 
         var a = BigUInt(328)
         a /= 21
-        XCTAssertEqual(a, 15)
+        #expect(a == 15)
         a %= 7
-        XCTAssertEqual(a, 1)
+        #expect(a == 1)
 
-        #if false
-            for x0 in (0 ... Int(Word.max)) {
-                for x1 in (0 ... Int(Word.max)).reverse() {
-                    for y0 in (0 ... Int(Word.max)).reverse() {
-                        for y1 in (1 ... Int(Word.max)).reverse() {
-                            for x2 in (1 ... y1).reverse() {
-                                test(
-                                    [Word(x0), Word(x1), Word(x2)],
-                                    [Word(y0), Word(y1)])
-                            }
-                        }
-                    }
-                }
-            }
-        #endif
     }
 
-    func testFactorial() {
+    @Test func factorial() {
         let power = 10
         var forward = BigUInt(1)
         for i in 1 ..< (1 << power) {
@@ -973,62 +919,62 @@ class BigUIntTests: XCTestCase {
         }
         let balanced = balancedFactorial(level: power, offset: 0)
 
-        XCTAssertEqual(backward, forward)
-        XCTAssertEqual(balanced, forward)
+        #expect(backward == forward)
+        #expect(balanced == forward)
 
         var remaining = balanced
         for i in 1 ..< (1 << power) {
             let (div, mod) = remaining.quotientAndRemainder(dividingBy: BigUInt(i))
-            XCTAssertEqual(mod, 0)
+            #expect(mod == 0)
             remaining = div
         }
-        XCTAssertEqual(remaining, 1)
+        #expect(remaining == 1)
     }
 
-    func testExponentiation() {
-        XCTAssertEqual(BigUInt(0).power(0), BigUInt(1))
-        XCTAssertEqual(BigUInt(0).power(1), BigUInt(0))
+    @Test func exponentiation_() {
+        #expect(BigUInt(0).power(0) == BigUInt(1))
+        #expect(BigUInt(0).power(1) == BigUInt(0))
 
-        XCTAssertEqual(BigUInt(1).power(0), BigUInt(1))
-        XCTAssertEqual(BigUInt(1).power(1), BigUInt(1))
-        XCTAssertEqual(BigUInt(1).power(-1), BigUInt(1))
-        XCTAssertEqual(BigUInt(1).power(-2), BigUInt(1))
-        XCTAssertEqual(BigUInt(1).power(-3), BigUInt(1))
-        XCTAssertEqual(BigUInt(1).power(-4), BigUInt(1))
+        #expect(BigUInt(1).power(0) == BigUInt(1))
+        #expect(BigUInt(1).power(1) == BigUInt(1))
+        #expect(BigUInt(1).power(-1) == BigUInt(1))
+        #expect(BigUInt(1).power(-2) == BigUInt(1))
+        #expect(BigUInt(1).power(-3) == BigUInt(1))
+        #expect(BigUInt(1).power(-4) == BigUInt(1))
 
-        XCTAssertEqual(BigUInt(2).power(0), BigUInt(1))
-        XCTAssertEqual(BigUInt(2).power(1), BigUInt(2))
-        XCTAssertEqual(BigUInt(2).power(2), BigUInt(4))
-        XCTAssertEqual(BigUInt(2).power(3), BigUInt(8))
-        XCTAssertEqual(BigUInt(2).power(-1), BigUInt(0))
-        XCTAssertEqual(BigUInt(2).power(-2), BigUInt(0))
-        XCTAssertEqual(BigUInt(2).power(-3), BigUInt(0))
+        #expect(BigUInt(2).power(0) == BigUInt(1))
+        #expect(BigUInt(2).power(1) == BigUInt(2))
+        #expect(BigUInt(2).power(2) == BigUInt(4))
+        #expect(BigUInt(2).power(3) == BigUInt(8))
+        #expect(BigUInt(2).power(-1) == BigUInt(0))
+        #expect(BigUInt(2).power(-2) == BigUInt(0))
+        #expect(BigUInt(2).power(-3) == BigUInt(0))
 
-        XCTAssertEqual(BigUInt(3).power(0), BigUInt(1))
-        XCTAssertEqual(BigUInt(3).power(1), BigUInt(3))
-        XCTAssertEqual(BigUInt(3).power(2), BigUInt(9))
-        XCTAssertEqual(BigUInt(3).power(3), BigUInt(27))
-        XCTAssertEqual(BigUInt(3).power(-1), BigUInt(0))
-        XCTAssertEqual(BigUInt(3).power(-2), BigUInt(0))
+        #expect(BigUInt(3).power(0) == BigUInt(1))
+        #expect(BigUInt(3).power(1) == BigUInt(3))
+        #expect(BigUInt(3).power(2) == BigUInt(9))
+        #expect(BigUInt(3).power(3) == BigUInt(27))
+        #expect(BigUInt(3).power(-1) == BigUInt(0))
+        #expect(BigUInt(3).power(-2) == BigUInt(0))
 
-        XCTAssertEqual((BigUInt(1) << 256).power(0), BigUInt(1))
-        XCTAssertEqual((BigUInt(1) << 256).power(1), BigUInt(1) << 256)
-        XCTAssertEqual((BigUInt(1) << 256).power(2), BigUInt(1) << 512)
+        #expect((BigUInt(1) << 256).power(0) == BigUInt(1))
+        #expect((BigUInt(1) << 256).power(1) == BigUInt(1) << 256)
+        #expect((BigUInt(1) << 256).power(2) == BigUInt(1) << 512)
 
-        XCTAssertEqual(BigUInt(0).power(577), BigUInt(0))
-        XCTAssertEqual(BigUInt(1).power(577), BigUInt(1))
-        XCTAssertEqual(BigUInt(2).power(577), BigUInt(1) << 577)
+        #expect(BigUInt(0).power(577) == BigUInt(0))
+        #expect(BigUInt(1).power(577) == BigUInt(1))
+        #expect(BigUInt(2).power(577) == BigUInt(1) << 577)
     }
 
-    func testModularExponentiation() {
-        XCTAssertEqual(BigUInt(2).power(11, modulus: 1), 0)
-        XCTAssertEqual(BigUInt(2).power(11, modulus: 1000), 48)
+    @Test func modularExponentiation_() {
+        #expect(BigUInt(2).power(11, modulus: 1) == 0)
+        #expect(BigUInt(2).power(11, modulus: 1000) == 48)
 
-        func test(a: BigUInt, p: BigUInt, file: StaticString = #file, line: UInt = #line) {
+        func test(a: BigUInt, p: BigUInt) {
             // For all primes p and integers a, a % p == a^p % p. (Fermat's Little Theorem)
             let x = a % p
             let y = x.power(p, modulus: p)
-            XCTAssertEqual(x, y, file: file, line: line)
+            #expect(x == y)
         }
 
         // Here are some primes
@@ -1047,188 +993,188 @@ class BigUIntTests: XCTestCase {
         test(a: m127, p: m521)
     }
 
-    func testBitWidth() {
-        XCTAssertEqual(BigUInt(0).bitWidth, 0)
-        XCTAssertEqual(BigUInt(1).bitWidth, 1)
-        XCTAssertEqual(BigUInt(Word.max).bitWidth, Word.bitWidth)
-        XCTAssertEqual(BigUInt(words: [Word.max, 1]).bitWidth, Word.bitWidth + 1)
-        XCTAssertEqual(BigUInt(words: [2, 12]).bitWidth, Word.bitWidth + 4)
-        XCTAssertEqual(BigUInt(words: [1, Word.max]).bitWidth, 2 * Word.bitWidth)
+    @Test func bitWidth_() {
+        #expect(BigUInt(0).bitWidth == 0)
+        #expect(BigUInt(1).bitWidth == 1)
+        #expect(BigUInt(Word.max).bitWidth == Word.bitWidth)
+        #expect(BigUInt(words: [Word.max, 1]).bitWidth == Word.bitWidth + 1)
+        #expect(BigUInt(words: [2, 12]).bitWidth == Word.bitWidth + 4)
+        #expect(BigUInt(words: [1, Word.max]).bitWidth == 2 * Word.bitWidth)
 
-        XCTAssertEqual(BigUInt(0).leadingZeroBitCount, 0)
-        XCTAssertEqual(BigUInt(1).leadingZeroBitCount, Word.bitWidth - 1)
-        XCTAssertEqual(BigUInt(Word.max).leadingZeroBitCount, 0)
-        XCTAssertEqual(BigUInt(words: [Word.max, 1]).leadingZeroBitCount, Word.bitWidth - 1)
-        XCTAssertEqual(BigUInt(words: [14, Word.max]).leadingZeroBitCount, 0)
+        #expect(BigUInt(0).leadingZeroBitCount == 0)
+        #expect(BigUInt(1).leadingZeroBitCount == Word.bitWidth - 1)
+        #expect(BigUInt(Word.max).leadingZeroBitCount == 0)
+        #expect(BigUInt(words: [Word.max, 1]).leadingZeroBitCount == Word.bitWidth - 1)
+        #expect(BigUInt(words: [14, Word.max]).leadingZeroBitCount == 0)
 
-        XCTAssertEqual(BigUInt(0).trailingZeroBitCount, 0)
-        XCTAssertEqual(BigUInt((1 as Word) << (Word.bitWidth - 1)).trailingZeroBitCount, Word.bitWidth - 1)
-        XCTAssertEqual(BigUInt(Word.max).trailingZeroBitCount, 0)
-        XCTAssertEqual(BigUInt(words: [0, 1]).trailingZeroBitCount, Word.bitWidth)
-        XCTAssertEqual(BigUInt(words: [0, 1 << Word(Word.bitWidth - 1)]).trailingZeroBitCount, 2 * Word.bitWidth - 1)
+        #expect(BigUInt(0).trailingZeroBitCount == 0)
+        #expect(BigUInt((1 as Word) << (Word.bitWidth - 1)).trailingZeroBitCount == Word.bitWidth - 1)
+        #expect(BigUInt(Word.max).trailingZeroBitCount == 0)
+        #expect(BigUInt(words: [0, 1]).trailingZeroBitCount == Word.bitWidth)
+        #expect(BigUInt(words: [0, 1 << Word(Word.bitWidth - 1)]).trailingZeroBitCount == 2 * Word.bitWidth - 1)
     }
 
-    func testBitwise() {
+    @Test func bitwise_() {
         let a = BigUInt("1234567890ABCDEF13579BDF2468ACE", radix: 16)!
         let b = BigUInt("ECA8642FDB97531FEDCBA0987654321", radix: 16)!
 
         //                                    a = 01234567890ABCDEF13579BDF2468ACE
         //                                    b = 0ECA8642FDB97531FEDCBA0987654321
-        XCTAssertEqual(String(~a,    radix: 16), "fedcba9876f543210eca86420db97531")
-        XCTAssertEqual(String(a | b, radix: 16),  "febc767fdbbfdfffffdfbbdf767cbef")
-        XCTAssertEqual(String(a & b, radix: 16),    "2044289083410f014380982440200")
-        XCTAssertEqual(String(a ^ b, radix: 16),  "fe9c32574b3c9ef0fe9c3b47523c9ef")
+        #expect(String(~a,    radix: 16) == "fedcba9876f543210eca86420db97531")
+        #expect(String(a | b, radix: 16) == "febc767fdbbfdfffffdfbbdf767cbef")
+        #expect(String(a & b, radix: 16) == "2044289083410f014380982440200")
+        #expect(String(a ^ b, radix: 16) == "fe9c32574b3c9ef0fe9c3b47523c9ef")
 
         let ffff = BigUInt(words: Array(repeating: Word.max, count: 30))
         let not = ~ffff
         let zero = BigUInt()
-        XCTAssertEqual(not, zero)
-        XCTAssertEqual(Array((~ffff).words), [])
-        XCTAssertEqual(a | ffff, ffff)
-        XCTAssertEqual(a | 0, a)
-        XCTAssertEqual(a & a, a)
-        XCTAssertEqual(a & 0, 0)
-        XCTAssertEqual(a & ffff, a)
-        XCTAssertEqual(~(a | b), (~a & ~b))
-        XCTAssertEqual(~(a & b), (~a | ~b).extract(..<(a&b).count))
-        XCTAssertEqual(a ^ a, 0)
-        XCTAssertEqual((a ^ b) ^ b, a)
-        XCTAssertEqual((a ^ b) ^ a, b)
+        #expect(not == zero)
+        #expect(Array((~ffff).words) == [])
+        #expect(a | ffff == ffff)
+        #expect(a | 0 == a)
+        #expect(a & a == a)
+        #expect(a & 0 == 0)
+        #expect(a & ffff == a)
+        #expect(~(a | b) == (~a & ~b))
+        #expect(~(a & b) == (~a | ~b).extract(..<(a&b).count))
+        #expect(a ^ a == 0)
+        #expect((a ^ b) ^ b == a)
+        #expect((a ^ b) ^ a == b)
 
         var z = a * b
         z |= a
         z &= b
         z ^= ffff
-        XCTAssertEqual(z, (((a * b) | a) & b) ^ ffff)
+        #expect(z == (((a * b) | a) & b) ^ ffff)
     }
 
-    func testLeftShifts() {
+    @Test func leftShifts() {
         let sample = BigUInt("123456789ABCDEF01234567891631832727633", radix: 16)!
 
         var a = sample
 
         a <<= 0
-        XCTAssertEqual(a, sample)
+        #expect(a == sample)
 
         a = sample
         a <<= 1
-        XCTAssertEqual(a, 2 * sample)
+        #expect(a == 2 * sample)
 
         a = sample
         a <<= Word.bitWidth
-        XCTAssertEqual(a.count, sample.count + 1)
-        XCTAssertEqual(a[0], 0)
-        XCTAssertEqual(a.extract(1 ... sample.count + 1), sample)
+        #expect(a.count == sample.count + 1)
+        #expect(a[0] == 0)
+        #expect(a.extract(1 ... sample.count + 1) == sample)
 
         a = sample
         a <<= 100 * Word.bitWidth
-        XCTAssertEqual(a.count, sample.count + 100)
-        XCTAssertEqual(a.extract(0 ..< 100), 0)
-        XCTAssertEqual(a.extract(100 ... sample.count + 100), sample)
+        #expect(a.count == sample.count + 100)
+        #expect(a.extract(0 ..< 100) == 0)
+        #expect(a.extract(100 ... sample.count + 100) == sample)
 
         a = sample
         a <<= 100 * Word.bitWidth + 2
-        XCTAssertEqual(a.count, sample.count + 100)
-        XCTAssertEqual(a.extract(0 ..< 100), 0)
-        XCTAssertEqual(a.extract(100 ... sample.count + 100), sample << 2)
+        #expect(a.count == sample.count + 100)
+        #expect(a.extract(0 ..< 100) == 0)
+        #expect(a.extract(100 ... sample.count + 100) == sample << 2)
 
         a = sample
         a <<= Word.bitWidth - 1
-        XCTAssertEqual(a.count, sample.count + 1)
-        XCTAssertEqual(a, BigUInt(words: [0] + sample.words) / 2)
+        #expect(a.count == sample.count + 1)
+        #expect(a == BigUInt(words: [0] + sample.words) / 2)
 
 
         a = sample
         a <<= -4
-        XCTAssertEqual(a, sample / 16)
+        #expect(a == sample / 16)
 
-        XCTAssertEqual(sample << 0, sample)
-        XCTAssertEqual(sample << 1, 2 * sample)
-        XCTAssertEqual(sample << 2, 4 * sample)
-        XCTAssertEqual(sample << 4, 16 * sample)
-        XCTAssertEqual(sample << Word.bitWidth, BigUInt(words: [0 as Word] + sample.words))
-        XCTAssertEqual(sample << (Word.bitWidth - 1), BigUInt(words: [0] + sample.words) / 2)
-        XCTAssertEqual(sample << (Word.bitWidth + 1), BigUInt(words: [0] + sample.words) * 2)
-        XCTAssertEqual(sample << (Word.bitWidth + 2), BigUInt(words: [0] + sample.words) * 4)
-        XCTAssertEqual(sample << (2 * Word.bitWidth), BigUInt(words: [0, 0] + sample.words))
-        XCTAssertEqual(sample << (2 * Word.bitWidth + 2), BigUInt(words: [0, 0] + (4 * sample).words))
+        #expect(sample << 0 == sample)
+        #expect(sample << 1 == 2 * sample)
+        #expect(sample << 2 == 4 * sample)
+        #expect(sample << 4 == 16 * sample)
+        #expect(sample << Word.bitWidth == BigUInt(words: [0 as Word] + sample.words))
+        #expect(sample << (Word.bitWidth - 1) == BigUInt(words: [0] + sample.words) / 2)
+        #expect(sample << (Word.bitWidth + 1) == BigUInt(words: [0] + sample.words) * 2)
+        #expect(sample << (Word.bitWidth + 2) == BigUInt(words: [0] + sample.words) * 4)
+        #expect(sample << (2 * Word.bitWidth) == BigUInt(words: [0, 0] + sample.words))
+        #expect(sample << (2 * Word.bitWidth + 2) == BigUInt(words: [0, 0] + (4 * sample).words))
 
-        XCTAssertEqual(sample << -1, sample / 2)
-        XCTAssertEqual(sample << -4, sample / 16)
+        #expect(sample << -1 == sample / 2)
+        #expect(sample << -4 == sample / 16)
     }
 
-    func testRightShifts() {
+    @Test func rightShifts() {
         let sample = BigUInt("123456789ABCDEF1234567891631832727633", radix: 16)!
 
         var a = sample
 
         a >>= BigUInt(0)
-        XCTAssertEqual(a, sample)
+        #expect(a == sample)
 
         a >>= 0
-        XCTAssertEqual(a, sample)
+        #expect(a == sample)
 
         a = sample
         a >>= 1
-        XCTAssertEqual(a, sample / 2)
+        #expect(a == sample / 2)
 
         a = sample
         a >>= Word.bitWidth
-        XCTAssertEqual(a, sample.extract(1...))
+        #expect(a == sample.extract(1...))
 
         a = sample
         a >>= Word.bitWidth + 2
-        XCTAssertEqual(a, sample.extract(1...) / 4)
+        #expect(a == sample.extract(1...) / 4)
 
         a = sample
         a >>= sample.count * Word.bitWidth
-        XCTAssertEqual(a, 0)
+        #expect(a == 0)
 
         a = sample
         a >>= 1000
-        XCTAssertEqual(a, 0)
+        #expect(a == 0)
 
         a = sample
         a >>= 100 * Word.bitWidth
-        XCTAssertEqual(a, 0)
+        #expect(a == 0)
 
         a = sample
         a >>= 100 * BigUInt(Word.max)
-        XCTAssertEqual(a, 0)
+        #expect(a == 0)
 
         a = sample
         a >>= -1
-        XCTAssertEqual(a, sample * 2)
+        #expect(a == sample * 2)
 
         a = sample
         a >>= -4
-        XCTAssertEqual(a, sample * 16)
+        #expect(a == sample * 16)
 
-        XCTAssertEqual(sample >> BigUInt(0), sample)
-        XCTAssertEqual(sample >> 0, sample)
-        XCTAssertEqual(sample >> 1, sample / 2)
-        XCTAssertEqual(sample >> 3, sample / 8)
-        XCTAssertEqual(sample >> Word.bitWidth, sample.extract(1 ..< sample.count))
-        XCTAssertEqual(sample >> (Word.bitWidth + 2), sample.extract(1...) / 4)
-        XCTAssertEqual(sample >> (Word.bitWidth + 3), sample.extract(1...) / 8)
-        XCTAssertEqual(sample >> (sample.count * Word.bitWidth), 0)
-        XCTAssertEqual(sample >> (100 * Word.bitWidth), 0)
-        XCTAssertEqual(sample >> (100 * BigUInt(Word.max)), 0)
+        #expect(sample >> BigUInt(0) == sample)
+        #expect(sample >> 0 == sample)
+        #expect(sample >> 1 == sample / 2)
+        #expect(sample >> 3 == sample / 8)
+        #expect(sample >> Word.bitWidth == sample.extract(1 ..< sample.count))
+        #expect(sample >> (Word.bitWidth + 2) == sample.extract(1...) / 4)
+        #expect(sample >> (Word.bitWidth + 3) == sample.extract(1...) / 8)
+        #expect(sample >> (sample.count * Word.bitWidth) == 0)
+        #expect(sample >> (100 * Word.bitWidth) == 0)
+        #expect(sample >> (100 * BigUInt(Word.max)) == 0)
 
-        XCTAssertEqual(sample >> -1, sample * 2)
-        XCTAssertEqual(sample >> -4, sample * 16)
+        #expect(sample >> -1 == sample * 2)
+        #expect(sample >> -4 == sample * 16)
     }
 
-    func testSquareRoot() {
+    @Test func squareRoot_() {
         let sample = BigUInt("123456789ABCDEF1234567891631832727633", radix: 16)!
 
-        XCTAssertEqual(BigUInt(0).squareRoot(), 0)
-        XCTAssertEqual(BigUInt(256).squareRoot(), 16)
+        #expect(BigUInt(0).squareRoot() == 0)
+        #expect(BigUInt(256).squareRoot() == 16)
 
-        func checkSqrt(_ value: BigUInt, file: StaticString = #file, line: UInt = #line) {
+        func checkSqrt(_ value: BigUInt) {
             let root = value.squareRoot()
-            XCTAssertLessThanOrEqual(root * root, value, "\(value)", file: file, line: line)
-            XCTAssertGreaterThan((root + 1) * (root + 1), value, "\(value)", file: file, line: line)
+            #expect(root * root <= value, "\(value)")
+            #expect((root + 1) * (root + 1) > value, "\(value)")
         }
         for i in 0 ... 100 {
             checkSqrt(BigUInt(i))
@@ -1240,43 +1186,43 @@ class BigUIntTests: XCTestCase {
         checkSqrt(sample * sample + 1)
     }
 
-    func testGCD() {
-        XCTAssertEqual(BigUInt(0).greatestCommonDivisor(with: 2982891), 2982891)
-        XCTAssertEqual(BigUInt(2982891).greatestCommonDivisor(with: 0), 2982891)
-        XCTAssertEqual(BigUInt(0).greatestCommonDivisor(with: 0), 0)
+    @Test func gcd_() {
+        #expect(BigUInt(0).greatestCommonDivisor(with: 2982891) == 2982891)
+        #expect(BigUInt(2982891).greatestCommonDivisor(with: 0) == 2982891)
+        #expect(BigUInt(0).greatestCommonDivisor(with: 0) == 0)
 
-        XCTAssertEqual(BigUInt(4).greatestCommonDivisor(with: 6), 2)
-        XCTAssertEqual(BigUInt(15).greatestCommonDivisor(with: 10), 5)
-        XCTAssertEqual(BigUInt(8 * 3 * 25 * 7).greatestCommonDivisor(with: 2 * 9 * 5 * 49), 2 * 3 * 5 * 7)
+        #expect(BigUInt(4).greatestCommonDivisor(with: 6) == 2)
+        #expect(BigUInt(15).greatestCommonDivisor(with: 10) == 5)
+        #expect(BigUInt(8 * 3 * 25 * 7).greatestCommonDivisor(with: 2 * 9 * 5 * 49) == 2 * 3 * 5 * 7)
 
         var fibo: [BigUInt] = [0, 1]
         for i in 0...10000 {
             fibo.append(fibo[i] + fibo[i + 1])
         }
 
-        XCTAssertEqual(BigUInt(fibo[100]).greatestCommonDivisor(with: fibo[101]), 1)
-        XCTAssertEqual(BigUInt(fibo[1000]).greatestCommonDivisor(with: fibo[1001]), 1)
-        XCTAssertEqual(BigUInt(fibo[10000]).greatestCommonDivisor(with: fibo[10001]), 1)
+        #expect(BigUInt(fibo[100]).greatestCommonDivisor(with: fibo[101]) == 1)
+        #expect(BigUInt(fibo[1000]).greatestCommonDivisor(with: fibo[1001]) == 1)
+        #expect(BigUInt(fibo[10000]).greatestCommonDivisor(with: fibo[10001]) == 1)
 
-        XCTAssertEqual(BigUInt(3 * 5 * 7 * 9).greatestCommonDivisor(with: 5 * 7 * 7), 5 * 7)
-        XCTAssertEqual(BigUInt(fibo[4]).greatestCommonDivisor(with: fibo[2]), fibo[2])
-        XCTAssertEqual(BigUInt(fibo[3 * 5 * 7 * 9]).greatestCommonDivisor(with: fibo[5 * 7 * 7 * 9]), fibo[5 * 7 * 9])
-        XCTAssertEqual(BigUInt(fibo[7 * 17 * 83]).greatestCommonDivisor(with: fibo[6 * 17 * 83]), fibo[17 * 83])
+        #expect(BigUInt(3 * 5 * 7 * 9).greatestCommonDivisor(with: 5 * 7 * 7) == 5 * 7)
+        #expect(BigUInt(fibo[4]).greatestCommonDivisor(with: fibo[2]) == fibo[2])
+        #expect(BigUInt(fibo[3 * 5 * 7 * 9]).greatestCommonDivisor(with: fibo[5 * 7 * 7 * 9]) == fibo[5 * 7 * 9])
+        #expect(BigUInt(fibo[7 * 17 * 83]).greatestCommonDivisor(with: fibo[6 * 17 * 83]) == fibo[17 * 83])
     }
 
-    func testInverse() {
-        XCTAssertNil(BigUInt(4).inverse(2))
-        XCTAssertNil(BigUInt(4).inverse(8))
-        XCTAssertNil(BigUInt(12).inverse(15))
-        XCTAssertEqual(BigUInt(13).inverse(15), 7)
+    @Test func inverse_() {
+        #expect(BigUInt(4).inverse(2) == nil)
+        #expect(BigUInt(4).inverse(8) == nil)
+        #expect(BigUInt(12).inverse(15) == nil)
+        #expect(BigUInt(13).inverse(15) == 7)
 
-        XCTAssertEqual(BigUInt(251).inverse(1023), 269)
-        XCTAssertNil(BigUInt(252).inverse(1023))
-        XCTAssertEqual(BigUInt(2).inverse(1023), 512)
+        #expect(BigUInt(251).inverse(1023) == 269)
+        #expect(BigUInt(252).inverse(1023) == nil)
+        #expect(BigUInt(2).inverse(1023) == 512)
     }
 
 
-    func testStrongProbablePrimeTest() {
+    @Test func strongProbablePrimeTest() {
         let primes: [BigUInt.Word] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 79, 83, 89, 97]
         let pseudoPrimes: [BigUInt] = [
             /*  2 */ 2_047,
@@ -1298,119 +1244,119 @@ class BigUIntTests: XCTestCase {
             print(candidate)
             // SPPT should not rule out candidate's primality for primes less than prime[i + 1]
             for j in 0...i {
-                XCTAssertTrue(candidate.isStrongProbablePrime(BigUInt(primes[j])))
+                #expect(candidate.isStrongProbablePrime(BigUInt(primes[j])))
             }
             // But the pseudoprimes aren't prime, so there is a base that disproves them.
             let foo = (i + 1 ... i + 3).filter { !candidate.isStrongProbablePrime(BigUInt(primes[$0])) }
-            XCTAssertNotEqual(foo, [])
+            #expect(foo != [])
         }
 
         // Try the SPPT for some Mersenne numbers.
 
         // Mersenne exponents from OEIS: https://oeis.org/A000043
-        XCTAssertFalse((BigUInt(1) << 606 - BigUInt(1)).isStrongProbablePrime(5))
-        XCTAssertTrue((BigUInt(1) << 607 - BigUInt(1)).isStrongProbablePrime(5)) // 2^607 - 1 is prime
-        XCTAssertFalse((BigUInt(1) << 608 - BigUInt(1)).isStrongProbablePrime(5))
+        #expect(!(BigUInt(1) << 606 - BigUInt(1)).isStrongProbablePrime(5))
+        #expect((BigUInt(1) << 607 - BigUInt(1)).isStrongProbablePrime(5)) // 2^607 - 1 is prime
+        #expect(!(BigUInt(1) << 608 - BigUInt(1)).isStrongProbablePrime(5))
 
-        XCTAssertFalse((BigUInt(1) << 520 - BigUInt(1)).isStrongProbablePrime(7))
-        XCTAssertTrue((BigUInt(1) << 521 - BigUInt(1)).isStrongProbablePrime(7)) // 2^521 -1 is prime
-        XCTAssertFalse((BigUInt(1) << 522 - BigUInt(1)).isStrongProbablePrime(7))
+        #expect(!(BigUInt(1) << 520 - BigUInt(1)).isStrongProbablePrime(7))
+        #expect((BigUInt(1) << 521 - BigUInt(1)).isStrongProbablePrime(7)) // 2^521 -1 is prime
+        #expect(!(BigUInt(1) << 522 - BigUInt(1)).isStrongProbablePrime(7))
 
-        XCTAssertFalse((BigUInt(1) << 88 - BigUInt(1)).isStrongProbablePrime(128))
-        XCTAssertTrue((BigUInt(1) << 89 - BigUInt(1)).isStrongProbablePrime(128)) // 2^89 -1 is prime
-        XCTAssertFalse((BigUInt(1) << 90 - BigUInt(1)).isStrongProbablePrime(128))
+        #expect(!(BigUInt(1) << 88 - BigUInt(1)).isStrongProbablePrime(128))
+        #expect((BigUInt(1) << 89 - BigUInt(1)).isStrongProbablePrime(128)) // 2^89 -1 is prime
+        #expect(!(BigUInt(1) << 90 - BigUInt(1)).isStrongProbablePrime(128))
 
         // One extra test to exercise an a^2 % modulus == 1 case
-        XCTAssertFalse(BigUInt(217).isStrongProbablePrime(129))
+        #expect(!BigUInt(217).isStrongProbablePrime(129))
     }
 
-    func testIsPrime() {
-        XCTAssertFalse(BigUInt(0).isPrime())
-        XCTAssertFalse(BigUInt(1).isPrime())
-        XCTAssertTrue(BigUInt(2).isPrime())
-        XCTAssertTrue(BigUInt(3).isPrime())
-        XCTAssertFalse(BigUInt(4).isPrime())
-        XCTAssertTrue(BigUInt(5).isPrime())
+    @Test func isPrime() {
+        #expect(!BigUInt(0).isPrime())
+        #expect(!BigUInt(1).isPrime())
+        #expect(BigUInt(2).isPrime())
+        #expect(BigUInt(3).isPrime())
+        #expect(!BigUInt(4).isPrime())
+        #expect(BigUInt(5).isPrime())
 
         // Try primality testing the first couple hundred Mersenne numbers comparing against the first few Mersenne exponents from OEIS: https://oeis.org/A000043
         let mp: Set<Int> = [2, 3, 5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521]
         for exponent in 2..<200 {
             let m = BigUInt(1) << exponent - 1
-            XCTAssertEqual(m.isPrime(), mp.contains(exponent), "\(exponent)")
+            #expect(m.isPrime() == mp.contains(exponent), "\(exponent)")
         }
     }
 
-    func testConversionToString() {
+    @Test func conversionToString() {
         let sample = BigUInt("123456789ABCDEFEDCBA98765432123456789ABCDEF", radix: 16)!
         // Radix = 10
-        XCTAssertEqual(String(BigUInt()), "0")
-        XCTAssertEqual(String(BigUInt(1)), "1")
-        XCTAssertEqual(String(BigUInt(100)), "100")
-        XCTAssertEqual(String(BigUInt(12345)), "12345")
-        XCTAssertEqual(String(BigUInt(123456789)), "123456789")
-        XCTAssertEqual(String(sample), "425693205796080237694414176550132631862392541400559")
+        #expect(String(BigUInt()) == "0")
+        #expect(String(BigUInt(1)) == "1")
+        #expect(String(BigUInt(100)) == "100")
+        #expect(String(BigUInt(12345)) == "12345")
+        #expect(String(BigUInt(123456789)) == "123456789")
+        #expect(String(sample) == "425693205796080237694414176550132631862392541400559")
 
         // Radix = 16
-        XCTAssertEqual(String(BigUInt(0x1001), radix: 16), "1001")
-        XCTAssertEqual(String(BigUInt(0x0102030405060708), radix: 16), "102030405060708")
-        XCTAssertEqual(String(sample, radix: 16), "123456789abcdefedcba98765432123456789abcdef")
-        XCTAssertEqual(String(sample, radix: 16, uppercase: true), "123456789ABCDEFEDCBA98765432123456789ABCDEF")
+        #expect(String(BigUInt(0x1001), radix: 16) == "1001")
+        #expect(String(BigUInt(0x0102030405060708), radix: 16) == "102030405060708")
+        #expect(String(sample, radix: 16) == "123456789abcdefedcba98765432123456789abcdef")
+        #expect(String(sample, radix: 16, uppercase: true) == "123456789ABCDEFEDCBA98765432123456789ABCDEF")
 
         // Radix = 2
-        XCTAssertEqual(String(BigUInt(12), radix: 2), "1100")
-        XCTAssertEqual(String(BigUInt(123), radix: 2), "1111011")
-        XCTAssertEqual(String(BigUInt(1234), radix: 2), "10011010010")
-        XCTAssertEqual(String(sample, radix: 2), "1001000110100010101100111100010011010101111001101111011111110110111001011101010011000011101100101010000110010000100100011010001010110011110001001101010111100110111101111")
+        #expect(String(BigUInt(12), radix: 2) == "1100")
+        #expect(String(BigUInt(123), radix: 2) == "1111011")
+        #expect(String(BigUInt(1234), radix: 2) == "10011010010")
+        #expect(String(sample, radix: 2) == "1001000110100010101100111100010011010101111001101111011111110110111001011101010011000011101100101010000110010000100100011010001010110011110001001101010111100110111101111")
 
         // Radix = 31
-        XCTAssertEqual(String(BigUInt(30), radix: 31), "u")
-        XCTAssertEqual(String(BigUInt(31), radix: 31), "10")
-        XCTAssertEqual(String(BigUInt("10000000000000000", radix: 16)!, radix: 31), "nd075ib45k86g")
-        XCTAssertEqual(String(BigUInt("2908B5129F59DB6A41", radix: 16)!, radix: 31), "100000000000000")
-        XCTAssertEqual(String(sample, radix: 31), "ptf96helfaqi7ogc3jbonmccrhmnc2b61s")
+        #expect(String(BigUInt(30), radix: 31) == "u")
+        #expect(String(BigUInt(31), radix: 31) == "10")
+        #expect(String(BigUInt("10000000000000000", radix: 16)!, radix: 31) == "nd075ib45k86g")
+        #expect(String(BigUInt("2908B5129F59DB6A41", radix: 16)!, radix: 31) == "100000000000000")
+        #expect(String(sample, radix: 31) == "ptf96helfaqi7ogc3jbonmccrhmnc2b61s")
 
         let quickLook = BigUInt(513).playgroundDescription as? String
         if quickLook == "513 (10 bits)" {
         } else {
-            XCTFail("Unexpected playground QuickLook representation: \(quickLook ?? "nil")")
+            Issue.record("Unexpected playground QuickLook representation: \(quickLook ?? "nil")")
         }
     }
 
-    func testConversionFromString() {
+    @Test func conversionFromString() {
         let sample = "123456789ABCDEFEDCBA98765432123456789ABCDEF"
 
-        XCTAssertEqual(BigUInt("1"), 1)
-        XCTAssertEqual(BigUInt("123456789ABCDEF", radix: 16)!, 0x123456789ABCDEF)
-        XCTAssertEqual(BigUInt("1000000000000000000000"), BigUInt("3635C9ADC5DEA00000", radix: 16))
-        XCTAssertEqual(BigUInt("10000000000000000", radix: 16), BigUInt("18446744073709551616"))
-        XCTAssertEqual(BigUInt(sample, radix: 16)!, BigUInt("425693205796080237694414176550132631862392541400559"))
+        #expect(BigUInt("1") == 1)
+        #expect(BigUInt("123456789ABCDEF", radix: 16)! == 0x123456789ABCDEF)
+        #expect(BigUInt("1000000000000000000000") == BigUInt("3635C9ADC5DEA00000", radix: 16))
+        #expect(BigUInt("10000000000000000", radix: 16) == BigUInt("18446744073709551616"))
+        #expect(BigUInt(sample, radix: 16)! == BigUInt("425693205796080237694414176550132631862392541400559"))
 
         // We have to call BigUInt.init here because we don't want Literal initialization via coercion (SE-0213)
-        XCTAssertNil(BigUInt.init("Not a number"))
-        XCTAssertNil(BigUInt.init("X"))
-        XCTAssertNil(BigUInt.init("12349A"))
-        XCTAssertNil(BigUInt.init("000000000000000000000000A000"))
-        XCTAssertNil(BigUInt.init("00A0000000000000000000000000"))
-        XCTAssertNil(BigUInt.init("00 0000000000000000000000000"))
-        XCTAssertNil(BigUInt.init("\u{4e00}\u{4e03}")) // Chinese numerals "1", "7"
+        #expect(BigUInt.init("Not a number") == nil)
+        #expect(BigUInt.init("X") == nil)
+        #expect(BigUInt.init("12349A") == nil)
+        #expect(BigUInt.init("000000000000000000000000A000") == nil)
+        #expect(BigUInt.init("00A0000000000000000000000000") == nil)
+        #expect(BigUInt.init("00 0000000000000000000000000") == nil)
+        #expect(BigUInt.init("\u{4e00}\u{4e03}") == nil) // Chinese numerals "1", "7"
 
-        XCTAssertEqual(BigUInt("u", radix: 31)!, 30)
-        XCTAssertEqual(BigUInt("10", radix: 31)!, 31)
-        XCTAssertEqual(BigUInt("100000000000000", radix: 31)!, BigUInt("2908B5129F59DB6A41", radix: 16)!)
-        XCTAssertEqual(BigUInt("nd075ib45k86g", radix: 31)!, BigUInt("10000000000000000", radix: 16)!)
-        XCTAssertEqual(BigUInt("ptf96helfaqi7ogc3jbonmccrhmnc2b61s", radix: 31)!, BigUInt(sample, radix: 16)!)
+        #expect(BigUInt("u", radix: 31)! == 30)
+        #expect(BigUInt("10", radix: 31)! == 31)
+        #expect(BigUInt("100000000000000", radix: 31)! == BigUInt("2908B5129F59DB6A41", radix: 16)!)
+        #expect(BigUInt("nd075ib45k86g", radix: 31)! == BigUInt("10000000000000000", radix: 16)!)
+        #expect(BigUInt("ptf96helfaqi7ogc3jbonmccrhmnc2b61s", radix: 31)! == BigUInt(sample, radix: 16)!)
 
-        XCTAssertNotNil(BigUInt(sample.repeated(100), radix: 16))
+        #expect(BigUInt(sample.repeated(100), radix: 16) != nil)
    }
 
-    func testRandomIntegerWithMaximumWidth() {
-        XCTAssertEqual(BigUInt.randomInteger(withMaximumWidth: 0), 0)
+    @Test func randomIntegerWithMaximumWidth() {
+        #expect(BigUInt.randomInteger(withMaximumWidth: 0) == 0)
 
         let randomByte = BigUInt.randomInteger(withMaximumWidth: 8)
-        XCTAssertLessThan(randomByte, 256)
+        #expect(randomByte < 256)
 
         for _ in 0 ..< 100 {
-            XCTAssertLessThanOrEqual(BigUInt.randomInteger(withMaximumWidth: 1024).bitWidth, 1024)
+            #expect(BigUInt.randomInteger(withMaximumWidth: 1024).bitWidth <= 1024)
         }
 
         // Verify that all widths <= maximum are produced (with a tiny maximum)
@@ -1418,11 +1364,11 @@ class BigUIntTests: XCTestCase {
         var i = 0
         while !widths.isEmpty {
             let random = BigUInt.randomInteger(withMaximumWidth: 3)
-            XCTAssertLessThanOrEqual(random.bitWidth, 3)
+            #expect(random.bitWidth <= 3)
             widths.remove(random.bitWidth)
             i += 1
             if i > 4096 {
-                XCTFail("randomIntegerWithMaximumWidth doesn't seem random")
+                Issue.record("randomIntegerWithMaximumWidth doesn't seem random")
                 break
             }
         }
@@ -1440,19 +1386,19 @@ class BigUIntTests: XCTestCase {
         }
     }
 
-    func testRandomIntegerWithExactWidth() {
-        XCTAssertEqual(BigUInt.randomInteger(withExactWidth: 0), 0)
-        XCTAssertEqual(BigUInt.randomInteger(withExactWidth: 1), 1)
+    @Test func randomIntegerWithExactWidth() {
+        #expect(BigUInt.randomInteger(withExactWidth: 0) == 0)
+        #expect(BigUInt.randomInteger(withExactWidth: 1) == 1)
 
         for _ in 0 ..< 1024 {
             let randomByte = BigUInt.randomInteger(withExactWidth: 8)
-            XCTAssertEqual(randomByte.bitWidth, 8)
-            XCTAssertLessThan(randomByte, 256)
-            XCTAssertGreaterThanOrEqual(randomByte, 128)
+            #expect(randomByte.bitWidth == 8)
+            #expect(randomByte < 256)
+            #expect(randomByte >= 128)
         }
 
         for _ in 0 ..< 100 {
-            XCTAssertEqual(BigUInt.randomInteger(withExactWidth: 1024).bitWidth, 1024)
+            #expect(BigUInt.randomInteger(withExactWidth: 1024).bitWidth == 1024)
         }
 
         // Verify that all bits except the top are sometimes zero, sometimes one.
@@ -1468,7 +1414,7 @@ class BigUIntTests: XCTestCase {
         }
     }
 
-    func testRandomIntegerLessThan() {
+    @Test func randomIntegerLessThan() {
         // Verify that all bits in random integers generated by `randomIntegerLessThan` are sometimes zero, sometimes one.
         //
         // The limit starts with "11" so that generated random integers may easily begin with all combos.
@@ -1479,18 +1425,18 @@ class BigUIntTests: XCTestCase {
         var zeroBits = Set<Int>(0..<limit.bitWidth)
         for _ in 0..<100 {
             var random = BigUInt.randomInteger(lessThan: limit)
-            XCTAssertLessThan(random, limit)
+            #expect(random < limit)
             for i in 0..<limit.bitWidth {
                 if random[0] & 1 == 1 { oneBits.remove(i) }
                 else { zeroBits.remove(i) }
                 random >>= 1
             }
         }
-        XCTAssertEqual(oneBits, [])
-        XCTAssertEqual(zeroBits, [])
+        #expect(oneBits == [])
+        #expect(zeroBits == [])
     }
 
-    func testRandomFunctionsUseProvidedGenerator() {
+    @Test func randomFunctionsUseProvidedGenerator() {
         // Here I verify that each of the randomInteger functions uses the provided RNG, and not SystemRandomNumberGenerator.
         // This is important because all but BigUInt.randomInteger(withMaximumWidth:using:) are built on that base function, and it is easy to forget to pass along the provided generator and get a default SystemRandomNumberGenerator instead.
 
@@ -1514,7 +1460,7 @@ class BigUIntTests: XCTestCase {
             let expected = gen(body)
             for _ in 0 ..< 100 {
                 let actual = gen(body)
-                XCTAssertEqual(expected, actual)
+                #expect(expected == actual)
             }
         }
 

--- a/Tests/BigIntTests/BigUIntTests.swift
+++ b/Tests/BigIntTests/BigUIntTests.swift
@@ -26,16 +26,16 @@ extension BigUInt.Kind: Equatable {
 
     func check(_ value: BigUInt, _ kind: BigUInt.Kind?, _ words: [Word]) {
         if let kind = kind {
-            #expect(value.kind == kind, Comment(rawValue: "Mismatching kind: \(value.kind) vs. \(kind)"))
+            #expect(value.kind == kind, "Mismatching kind: \(value.kind) vs. \(kind)")
         }
-        #expect(Array(value.words) == words, Comment(rawValue: "Mismatching words: \(value.words) vs. \(words)"))
-        #expect(value.isZero == words.isEmpty, Comment(rawValue: "Mismatching isZero: \(value.isZero) vs. \(words.isEmpty)"))
-        #expect(value.count == words.count, Comment(rawValue: "Mismatching count: \(value.count) vs. \(words.count)"))
+        #expect(Array(value.words) == words, "Mismatching words: \(value.words) vs. \(words)")
+        #expect(value.isZero == words.isEmpty, "Mismatching isZero: \(value.isZero) vs. \(words.isEmpty)")
+        #expect(value.count == words.count, "Mismatching count: \(value.count) vs. \(words.count)")
         for i in 0 ..< words.count {
-            #expect(value[i] == words[i], Comment(rawValue: "Mismatching word at index \(i): \(value[i]) vs. \(words[i])"))
+            #expect(value[i] == words[i], "Mismatching word at index \(i): \(value[i]) vs. \(words[i])")
         }
         for i in words.count ..< words.count + 10 {
-            #expect(value[i] == 0, Comment(rawValue: "Expected 0 word at index \(i), got \(value[i])"))
+            #expect(value[i] == 0, "Expected 0 word at index \(i), got \(value[i])")
         }
     }
 

--- a/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
@@ -5,18 +5,18 @@ import Testing
 
 // MARK: - Asserts
 
-internal func XCTAssertWords(_ value: BigInt,
-                             _ expected: [UInt]) {
-  XCTAssertWords(
+internal func expectWords(_ value: BigInt,
+                          _ expected: [UInt]) {
+  expectWords(
     value: String(value, radix: 10, uppercase: false),
     words: Array(value.words),
     expected: expected
   )
 }
 
-private func XCTAssertWords(value: String,
-                            words: [UInt],
-                            expected: [UInt]) {
+private func expectWords(value: String,
+                         words: [UInt],
+                         expected: [UInt]) {
   #expect(words.count == expected.count, "Count for \(value)")
   guard words.count == expected.count else {
     return

--- a/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
+++ b/Tests/BigIntTests/Violet - Helpers/WordsTestCases.swift
@@ -1,37 +1,30 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
-
-import XCTest
+import Testing
 @testable import BigInt
 
 // MARK: - Asserts
 
 internal func XCTAssertWords(_ value: BigInt,
-                             _ expected: [UInt],
-                             file: StaticString = #file,
-                             line: UInt = #line) {
+                             _ expected: [UInt]) {
   XCTAssertWords(
     value: String(value, radix: 10, uppercase: false),
     words: Array(value.words),
-    expected: expected,
-    file: file,
-    line: line
+    expected: expected
   )
 }
 
 private func XCTAssertWords(value: String,
                             words: [UInt],
-                            expected: [UInt],
-                            file: StaticString,
-                            line: UInt) {
-  XCTAssertEqual(words.count, expected.count, "Count for \(value)", file: file, line: line)
+                            expected: [UInt]) {
+  #expect(words.count == expected.count, "Count for \(value)")
   guard words.count == expected.count else {
     return
   }
 
   // deconstruction nested in deconstruction? eh…
   for (index, (w, e)) in zip(words, expected).enumerated() {
-    XCTAssertEqual(w, e, "Word \(index) for \(value)", file: file, line: line)
+    #expect(w == e, "Word \(index) for \(value)")
   }
 }
 

--- a/Tests/BigIntTests/Violet - Property testing/ApplyA_ApplyB_Equals_ApplyAB.swift
+++ b/Tests/BigIntTests/Violet - Property testing/ApplyA_ApplyB_Equals_ApplyAB.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 // swiftlint:disable type_name
@@ -33,7 +33,7 @@ private struct TestCase {
 }
 
 private func createTestCases(_ op: TestCase.Operation,
-                             useBigNumbers: Bool = true) -> [TestCase] {
+                              useBigNumbers: Bool = true) -> [TestCase] {
   var strings = [
     "0",
     "1", "-1",
@@ -68,35 +68,28 @@ private func createTestCases(_ op: TestCase.Operation,
 ///
 /// This is not exactly associativity, because we will also do this for shifts:
 /// `(x >> a) >> b = x >> (a + b)`.
-class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
-
-  private lazy var values = generateBigIntValues(countButNotReally: 20)
+@Suite
+struct ApplyA_ApplyB_Equals_ApplyAB {
 
   // MARK: - Add
 
-  func test_add() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.addTest(value: int)
+  @Test
+  func add() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      addTest(value: int)
     }
   }
 
-  private let addTestCases = createTestCases(+)
+  private static let addTestCases = createTestCases(+)
 
-  private func addTest(value: BigInt,
-                       file: StaticString = #file,
-                       line: UInt = #line) {
-    for testCase in self.addTestCases {
+  private func addTest(value: BigInt) {
+    for testCase in Self.addTestCases {
       let a_b = value + testCase.a + testCase.b
       let ab = value + testCase.c
 
-      XCTAssertEqual(
-        a_b,
-        ab,
-        "\(value) + \(testCase.a) + \(testCase.b) vs \(value) + \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(a_b == ab, Comment(rawValue: "\(value) + \(testCase.a) + \(testCase.b) vs \(value) + \(testCase.c)"))
 
       var inoutA_B = value
       inoutA_B += testCase.a
@@ -106,42 +99,30 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
       inoutAB += testCase.c
       assert(inoutAB == ab)
 
-      XCTAssertEqual(
-        inoutA_B,
-        inoutAB,
-        "inout: \(value) + \(testCase.a) + \(testCase.b) vs \(value) + \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) + \(testCase.a) + \(testCase.b) vs \(value) + \(testCase.c)"))
     }
   }
 
   // MARK: - Sub
 
-  func test_sub() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.subTest(value: int)
+  @Test
+  func sub() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      subTest(value: int)
     }
   }
 
   // '+' because we need to add a + b
-  private let subTestCases = createTestCases(+)
+  private static let subTestCases = createTestCases(+)
 
-  private func subTest(value: BigInt,
-                       file: StaticString = #file,
-                       line: UInt = #line) {
-    for testCase in self.subTestCases {
+  private func subTest(value: BigInt) {
+    for testCase in Self.subTestCases {
       let a_b = value - testCase.a - testCase.b
       let ab = value - testCase.c
 
-      XCTAssertEqual(
-        a_b,
-        ab,
-        "\(value) - \(testCase.a) - \(testCase.b) vs \(value) - \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(a_b == ab, Comment(rawValue: "\(value) - \(testCase.a) - \(testCase.b) vs \(value) - \(testCase.c)"))
 
       var inoutA_B = value
       inoutA_B -= testCase.a
@@ -151,41 +132,29 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
       inoutAB -= testCase.c
       assert(inoutAB == ab)
 
-      XCTAssertEqual(
-        inoutA_B,
-        inoutAB,
-        "inout: \(value) - \(testCase.a) - \(testCase.b) vs \(value) - \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) - \(testCase.a) - \(testCase.b) vs \(value) - \(testCase.c)"))
     }
   }
 
   // MARK: - Mul
 
-  func test_mul() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.mulTest(value: int)
+  @Test
+  func mul() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      mulTest(value: int)
     }
   }
 
-  private let mulTestCases = createTestCases(*, useBigNumbers: false)
+  private static let mulTestCases = createTestCases(*, useBigNumbers: false)
 
-  private func mulTest(value: BigInt,
-                       file: StaticString = #file,
-                       line: UInt = #line) {
-    for testCase in self.mulTestCases {
+  private func mulTest(value: BigInt) {
+    for testCase in Self.mulTestCases {
       let a_b = value * testCase.a * testCase.b
       let ab = value * testCase.c
 
-      XCTAssertEqual(
-        a_b,
-        ab,
-        "\(value) * \(testCase.a) * \(testCase.b) vs \(value) * \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(a_b == ab, Comment(rawValue: "\(value) * \(testCase.a) * \(testCase.b) vs \(value) * \(testCase.c)"))
 
       var inoutA_B = value
       inoutA_B *= testCase.a
@@ -195,46 +164,34 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
       inoutAB *= testCase.c
       assert(inoutAB == ab)
 
-      XCTAssertEqual(
-        inoutA_B,
-        inoutAB,
-        "inout: \(value) * \(testCase.a) * \(testCase.b) vs \(value) * \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) * \(testCase.a) * \(testCase.b) vs \(value) * \(testCase.c)"))
     }
   }
 
   // MARK: - Div
 
-  func test_div() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.divTest(value: int)
+  @Test
+  func div() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      divTest(value: int)
     }
   }
 
-  private let divTestCases = [
+  private static let divTestCases = [
     TestCase(*, a: "3", b: "5"),
     TestCase(*, a: "3", b: "-5"),
     TestCase(*, a: "-3", b: "5"),
     TestCase(*, a: "-3", b: "-5")
   ]
 
-  private func divTest(value: BigInt,
-                       file: StaticString = #file,
-                       line: UInt = #line) {
-    for testCase in self.divTestCases {
+  private func divTest(value: BigInt) {
+    for testCase in Self.divTestCases {
       let a_b = value / testCase.a / testCase.b
       let ab = value / testCase.c
 
-      XCTAssertEqual(
-        a_b,
-        ab,
-        "\(value) / \(testCase.a) / \(testCase.b) vs \(value) / \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(a_b == ab, Comment(rawValue: "\(value) / \(testCase.a) / \(testCase.b) vs \(value) / \(testCase.c)"))
 
       var inoutA_B = value
       inoutA_B /= testCase.a
@@ -244,33 +201,31 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
       inoutAB /= testCase.c
       assert(inoutAB == ab)
 
-      XCTAssertEqual(
-        inoutA_B,
-        inoutAB,
-        "inout: \(value) / \(testCase.a) / \(testCase.b) vs \(value) / \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) / \(testCase.a) / \(testCase.b) vs \(value) / \(testCase.c)"))
     }
   }
 
   // MARK: - Left shift
 
-  func test_shiftLeft() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.shiftLeftTest(value: int)
+  @Test
+  func shiftLeft() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      shiftLeftTest(value: int)
     }
   }
 
-  func test_shiftLeft_heap() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.shiftLeftTest(value: int)
+  @Test
+  func shiftLeft_heap() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      shiftLeftTest(value: int)
     }
   }
 
-  private let shiftLeftTestCases: [TestCase] = [
+  private static let shiftLeftTestCases: [TestCase] = [
     TestCase(+, a: 1, b: 0),
     TestCase(+, a: 1, b: 1),
     TestCase(+, a: 3, b: 5),
@@ -278,20 +233,12 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
     TestCase(+, a: Word.bitWidth - 5, b: 7)
   ]
 
-  private func shiftLeftTest(value: BigInt,
-                             file: StaticString = #file,
-                             line: UInt = #line) {
-    for testCase in self.shiftLeftTestCases {
+  private func shiftLeftTest(value: BigInt) {
+    for testCase in Self.shiftLeftTestCases {
       let a_b = (value << testCase.a) << testCase.b
       let ab = value << testCase.c
 
-      XCTAssertEqual(
-        a_b,
-        ab,
-        "(\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(a_b == ab, Comment(rawValue: "(\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \(testCase.c)"))
 
       var inoutA_B = value
       inoutA_B <<= testCase.a
@@ -301,35 +248,33 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
       inoutAB <<= testCase.c
       assert(inoutAB == ab)
 
-      XCTAssertEqual(
-        inoutA_B,
-        inoutAB,
-        "inout: (\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: (\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \(testCase.c)"))
     }
   }
 
   // MARK: - Right shift
 
-  func test_shiftRight() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.shiftRightTest(value: int)
+  @Test
+  func shiftRight() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      shiftRightTest(value: int)
     }
   }
 
-  func test_shiftRight_heap() {
-    for raw in self.values {
-      let int = self.create(raw)
-      self.shiftRightTest(value: int)
+  @Test
+  func shiftRight_heap() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    for raw in values {
+      let int = create(raw)
+      shiftRightTest(value: int)
     }
   }
 
   // Right shift for more than 'Word.bitWidth' has a high probability
   // of shifting value into oblivion (0 or -1).
-  private let shiftRightTestCases: [TestCase] = [
+  private static let shiftRightTestCases: [TestCase] = [
     TestCase(+, a: 1, b: 0),
     TestCase(+, a: 1, b: 1),
     TestCase(+, a: 3, b: 5),
@@ -337,20 +282,12 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
     TestCase(+, a: Word.bitWidth - 5, b: 7)
   ]
 
-  private func shiftRightTest(value: BigInt,
-                              file: StaticString = #file,
-                              line: UInt = #line) {
-    for testCase in self.shiftRightTestCases {
+  private func shiftRightTest(value: BigInt) {
+    for testCase in Self.shiftRightTestCases {
       let a_b = (value >> testCase.a) >> testCase.b
       let ab = value >> testCase.c
 
-      XCTAssertEqual(
-        a_b,
-        ab,
-        "(\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(a_b == ab, Comment(rawValue: "(\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \(testCase.c)"))
 
       var inoutA_B = value
       inoutA_B >>= testCase.a
@@ -360,13 +297,7 @@ class ApplyA_ApplyB_Equals_ApplyAB: XCTestCase {
       inoutAB >>= testCase.c
       assert(inoutAB == ab)
 
-      XCTAssertEqual(
-        inoutA_B,
-        inoutAB,
-        "inout: (\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \(testCase.c)",
-        file: file,
-        line: line
-      )
+      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: (\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \(testCase.c)"))
     }
   }
 

--- a/Tests/BigIntTests/Violet - Property testing/ApplyA_ApplyB_Equals_ApplyAB.swift
+++ b/Tests/BigIntTests/Violet - Property testing/ApplyA_ApplyB_Equals_ApplyAB.swift
@@ -89,7 +89,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       let a_b = value + testCase.a + testCase.b
       let ab = value + testCase.c
 
-      #expect(a_b == ab, Comment(rawValue: "\(value) + \(testCase.a) + \(testCase.b) vs \(value) + \(testCase.c)"))
+      #expect(a_b == ab, "\(value) + \(testCase.a) + \(testCase.b) vs \(value) + \( testCase.c)")
 
       var inoutA_B = value
       inoutA_B += testCase.a
@@ -99,7 +99,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       inoutAB += testCase.c
       assert(inoutAB == ab)
 
-      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) + \(testCase.a) + \(testCase.b) vs \(value) + \(testCase.c)"))
+      #expect(inoutA_B == inoutAB, "inout: \(value) + \(testCase.a) + \(testCase.b) vs \(value) + \( testCase.c)")
     }
   }
 
@@ -122,7 +122,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       let a_b = value - testCase.a - testCase.b
       let ab = value - testCase.c
 
-      #expect(a_b == ab, Comment(rawValue: "\(value) - \(testCase.a) - \(testCase.b) vs \(value) - \(testCase.c)"))
+      #expect(a_b == ab, "\(value) - \(testCase.a) - \(testCase.b) vs \(value) - \( testCase.c)")
 
       var inoutA_B = value
       inoutA_B -= testCase.a
@@ -132,7 +132,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       inoutAB -= testCase.c
       assert(inoutAB == ab)
 
-      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) - \(testCase.a) - \(testCase.b) vs \(value) - \(testCase.c)"))
+      #expect(inoutA_B == inoutAB, "inout: \(value) - \(testCase.a) - \(testCase.b) vs \(value) - \( testCase.c)")
     }
   }
 
@@ -154,7 +154,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       let a_b = value * testCase.a * testCase.b
       let ab = value * testCase.c
 
-      #expect(a_b == ab, Comment(rawValue: "\(value) * \(testCase.a) * \(testCase.b) vs \(value) * \(testCase.c)"))
+      #expect(a_b == ab, "\(value) * \(testCase.a) * \(testCase.b) vs \(value) * \( testCase.c)")
 
       var inoutA_B = value
       inoutA_B *= testCase.a
@@ -164,7 +164,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       inoutAB *= testCase.c
       assert(inoutAB == ab)
 
-      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) * \(testCase.a) * \(testCase.b) vs \(value) * \(testCase.c)"))
+      #expect(inoutA_B == inoutAB, "inout: \(value) * \(testCase.a) * \(testCase.b) vs \(value) * \( testCase.c)")
     }
   }
 
@@ -191,7 +191,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       let a_b = value / testCase.a / testCase.b
       let ab = value / testCase.c
 
-      #expect(a_b == ab, Comment(rawValue: "\(value) / \(testCase.a) / \(testCase.b) vs \(value) / \(testCase.c)"))
+      #expect(a_b == ab, "\(value) / \(testCase.a) / \(testCase.b) vs \(value) / \( testCase.c)")
 
       var inoutA_B = value
       inoutA_B /= testCase.a
@@ -201,7 +201,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       inoutAB /= testCase.c
       assert(inoutAB == ab)
 
-      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: \(value) / \(testCase.a) / \(testCase.b) vs \(value) / \(testCase.c)"))
+      #expect(inoutA_B == inoutAB, "inout: \(value) / \(testCase.a) / \(testCase.b) vs \(value) / \( testCase.c)")
     }
   }
 
@@ -238,7 +238,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       let a_b = (value << testCase.a) << testCase.b
       let ab = value << testCase.c
 
-      #expect(a_b == ab, Comment(rawValue: "(\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \(testCase.c)"))
+      #expect(a_b == ab, "(\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \( testCase.c)")
 
       var inoutA_B = value
       inoutA_B <<= testCase.a
@@ -248,7 +248,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       inoutAB <<= testCase.c
       assert(inoutAB == ab)
 
-      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: (\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \(testCase.c)"))
+      #expect(inoutA_B == inoutAB, "inout: (\(value) << \(testCase.a)) << \(testCase.b) vs \(value) << \( testCase.c)")
     }
   }
 
@@ -287,7 +287,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       let a_b = (value >> testCase.a) >> testCase.b
       let ab = value >> testCase.c
 
-      #expect(a_b == ab, Comment(rawValue: "(\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \(testCase.c)"))
+      #expect(a_b == ab, "(\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \( testCase.c)")
 
       var inoutA_B = value
       inoutA_B >>= testCase.a
@@ -297,7 +297,7 @@ struct ApplyA_ApplyB_Equals_ApplyAB {
       inoutAB >>= testCase.c
       assert(inoutAB == ab)
 
-      #expect(inoutA_B == inoutAB, Comment(rawValue: "inout: (\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \(testCase.c)"))
+      #expect(inoutA_B == inoutAB, "inout: (\(value) >> \(testCase.a)) >> \(testCase.b) vs \(value) >> \( testCase.c)")
     }
   }
 

--- a/Tests/BigIntTests/Violet - Property testing/ApplyA_UndoA.swift
+++ b/Tests/BigIntTests/Violet - Property testing/ApplyA_UndoA.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 // swiftlint:disable type_name
@@ -10,40 +10,49 @@ private typealias Word = BigInt.Word
 
 /// Operations for which exists 'reverse' operation that undoes its effect.
 /// For example for addition it is subtraction: `(n + x) - x = n`.
-class ApplyA_UndoA: XCTestCase {
-
-  private lazy var values = generateBigIntValues(countButNotReally: 20)
-  private lazy var pairs = allPossiblePairings(lhs: self.values, rhs: self.values)
+@Suite
+struct ApplyA_UndoA {
 
   // MARK: - Tests
 
-  func test_addSub() {
-    for (lhsRaw, rhsRaw) in self.pairs {
-      let lhs = self.create(lhsRaw)
-      let rhs = self.create(rhsRaw)
+  @Test
+  func addSub() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    let pairs = allPossiblePairings(lhs: values, rhs: values)
+    
+    for (lhsRaw, rhsRaw) in pairs {
+      let lhs = create(lhsRaw)
+      let rhs = create(rhsRaw)
 
       let expectedLhs = (lhs + rhs) - rhs
-      XCTAssertEqual(lhs, expectedLhs, "\(lhs) +- \(rhs)")
+      #expect(lhs == expectedLhs, "\(lhs) +- \(rhs)")
     }
   }
 
-  func test_mulDiv() {
-    for (lhsRaw, rhsRaw) in self.pairs {
+  @Test
+  func mulDiv() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    let pairs = allPossiblePairings(lhs: values, rhs: values)
+    
+    for (lhsRaw, rhsRaw) in pairs {
       if rhsRaw.isZero {
         continue
       }
 
-      let lhs = self.create(lhsRaw)
-      let rhs = self.create(rhsRaw)
+      let lhs = create(lhsRaw)
+      let rhs = create(rhsRaw)
 
       let expectedLhs = (lhs * rhs) / rhs
-      XCTAssertEqual(lhs, expectedLhs, "\(lhs) */ \(rhs)")
+      #expect(lhs == expectedLhs, "\(lhs) */ \(rhs)")
     }
   }
 
-  func test_shiftLeftRight() {
-    for raw in self.values {
-      let value = self.create(raw)
+  @Test
+  func shiftLeftRight() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    
+    for raw in values {
+      let value = create(raw)
 
       let lessThanWord = 5
       let word = Word.bitWidth
@@ -51,23 +60,26 @@ class ApplyA_UndoA: XCTestCase {
 
       for count in [lessThanWord, word, moreThanWord] {
         let result = (value << count) >> count
-        XCTAssertEqual(result, value, "\(value) <<>> \(count)")
+        #expect(result == value, "\(value) <<>> \(count)")
       }
     }
   }
 
-  func test_toStringInit() {
-    for raw in self.values {
-      let value = self.create(raw)
+  @Test
+  func toStringInit() {
+    let values = generateBigIntValues(countButNotReally: 20)
+    
+    for raw in values {
+      let value = create(raw)
 
       for radix in [2, 5, 10, 16] {
         let string = String(value, radix: radix)
         guard let int = BigInt(string, radix: radix) else {
-          XCTFail("string: \(string), radix: \(radix)")
+          Issue.record("string: \(string), radix: \(radix)")
           continue
         }
 
-        XCTAssertEqual(int, value, "string: \(string)")
+        #expect(int == value, "string: \(string)")
       }
     }
   }

--- a/Tests/BigIntTests/Violet/BigIntCOWTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntCOWTests.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 // swiftlint:disable file_length
@@ -9,7 +9,8 @@ import XCTest
 private typealias Smi = Int32
 private typealias Word = BigInt.Word
 
-class BigIntCOWTests: XCTestCase {
+@Suite
+struct BigIntCOWTests {
 
   // This can't be '1' because 'n *= 1 -> n' (which is one of our test cases)
   private let smiValue = BigInt(2)
@@ -20,102 +21,107 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_plus_doesNotModifyOriginal() {
+  @Test
+  func plus_doesNotModifyOriginal() {
     // +smi
     var value = BigInt(Smi.max)
     _ = +value
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // +heap
     value = BigInt(Word.max)
     _ = +value
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   // MARK: - Minus
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_minus_doesNotModifyOriginal() {
+  @Test
+  func minus_doesNotModifyOriginal() {
     // -smi
     var value = BigInt(Smi.max)
     _ = -value
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // -heap
     value = BigInt(Word.max)
     _ = -value
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   // MARK: - Invert
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_invert_doesNotModifyOriginal() {
+  @Test
+  func invert_doesNotModifyOriginal() {
     // ~smi
     var value = BigInt(Smi.max)
     _ = ~value
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // ~heap
     value = BigInt(Word.max)
     _ = ~value
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   // MARK: - Add
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_add_toCopy_doesNotModifyOriginal() {
+  @Test
+  func add_toCopy_doesNotModifyOriginal() {
     // smi + smi
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy + self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi + heap
     value = BigInt(Smi.max)
     copy = value
     _ = copy + self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap + smi
     value = BigInt(Word.max)
     copy = value
     _ = copy + self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap + heap
     value = BigInt(Word.max)
     copy = value
     _ = copy + self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_add_toInout_doesNotModifyOriginal() {
+  @Test
+  func add_toInout_doesNotModifyOriginal() {
     // smi + smi
     var value = BigInt(Smi.max)
     self.addSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi + heap
     value = BigInt(Smi.max)
     self.addHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap + smi
     value = BigInt(Word.max)
     self.addSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap + heap
     value = BigInt(Word.max)
     self.addHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func addSmi(toInout value: inout BigInt) {
@@ -126,52 +132,54 @@ class BigIntCOWTests: XCTestCase {
     _ = value + self.heapValue
   }
 
-  func test_addEqual_toCopy_doesNotModifyOriginal() {
+  @Test
+  func addEqual_toCopy_doesNotModifyOriginal() {
     // smi + smi
     var value = BigInt(Smi.max)
     var copy = value
     copy += self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi + heap
     value = BigInt(Smi.max)
     copy = value
     copy += self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap + smi
     value = BigInt(Word.max)
     copy = value
     copy += self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap + heap
     value = BigInt(Word.max)
     copy = value
     copy += self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_addEqual_toInout_doesModifyOriginal() {
+  @Test
+  func addEqual_toInout_doesModifyOriginal() {
     // smi + smi
     var value = BigInt(Smi.max)
     self.addEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // smi + heap
     value = BigInt(Smi.max)
     self.addEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // heap + smi
     value = BigInt(Word.max)
     self.addEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
 
     // heap + heap
     value = BigInt(Word.max)
     self.addEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func addEqualSmi(toInout value: inout BigInt) {
@@ -186,54 +194,56 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_sub_toCopy_doesNotModifyOriginal() {
+  @Test
+  func sub_toCopy_doesNotModifyOriginal() {
     // smi - smi
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy - self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi - heap
     value = BigInt(Smi.max)
     copy = value
     _ = copy - self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap - smi
     value = BigInt(Word.max)
     copy = value
     _ = copy - self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap - heap
     value = BigInt(Word.max)
     copy = value
     _ = copy - self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_sub_toInout_doesNotModifyOriginal() {
+  @Test
+  func sub_toInout_doesNotModifyOriginal() {
     // smi - smi
     var value = BigInt(Smi.max)
     self.subSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi - heap
     value = BigInt(Smi.max)
     self.subHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap - smi
     value = BigInt(Word.max)
     self.subSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap - heap
     value = BigInt(Word.max)
     self.subHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func subSmi(toInout value: inout BigInt) {
@@ -244,52 +254,54 @@ class BigIntCOWTests: XCTestCase {
     _ = value - self.heapValue
   }
 
-  func test_subEqual_toCopy_doesNotModifyOriginal() {
+  @Test
+  func subEqual_toCopy_doesNotModifyOriginal() {
     // smi - smi
     var value = BigInt(Smi.max)
     var copy = value
     copy -= self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi - heap
     value = BigInt(Smi.max)
     copy = value
     copy -= self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap - smi
     value = BigInt(Word.max)
     copy = value
     copy -= self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap - heap
     value = BigInt(Word.max)
     copy = value
     copy -= self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_subEqual_toInout_doesModifyOriginal() {
+  @Test
+  func subEqual_toInout_doesModifyOriginal() {
     // smi - smi
     var value = BigInt(Smi.max)
     self.subEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // smi - heap
     value = BigInt(Smi.max)
     self.subEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // heap - smi
     value = BigInt(Word.max)
     self.subEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
 
     // heap - heap
     value = BigInt(Word.max)
     self.subEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func subEqualSmi(toInout value: inout BigInt) {
@@ -304,54 +316,56 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_mul_toCopy_doesNotModifyOriginal() {
+  @Test
+  func mul_toCopy_doesNotModifyOriginal() {
     // smi * smi
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy * self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi * heap
     value = BigInt(Smi.max)
     copy = value
     _ = copy * self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap * smi
     value = BigInt(Word.max)
     copy = value
     _ = copy * self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap * heap
     value = BigInt(Word.max)
     copy = value
     _ = copy * self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_mul_toInout_doesNotModifyOriginal() {
+  @Test
+  func mul_toInout_doesNotModifyOriginal() {
     // smi * smi
     var value = BigInt(Smi.max)
     self.mulSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi * heap
     value = BigInt(Smi.max)
     self.mulHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap * smi
     value = BigInt(Word.max)
     self.mulSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap * heap
     value = BigInt(Word.max)
     self.mulHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func mulSmi(toInout value: inout BigInt) {
@@ -362,52 +376,54 @@ class BigIntCOWTests: XCTestCase {
     _ = value * self.heapValue
   }
 
-  func test_mulEqual_toCopy_doesNotModifyOriginal() {
+  @Test
+  func mulEqual_toCopy_doesNotModifyOriginal() {
     // smi * smi
     var value = BigInt(Smi.max)
     var copy = value
     copy *= self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi * heap
     value = BigInt(Smi.max)
     copy = value
     copy *= self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap * smi
     value = BigInt(Word.max)
     copy = value
     copy *= self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap * heap
     value = BigInt(Word.max)
     copy = value
     copy *= self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_mulEqual_toInout_doesModifyOriginal() {
+  @Test
+  func mulEqual_toInout_doesModifyOriginal() {
     // smi * smi
     var value = BigInt(Smi.max)
     self.mulEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // smi * heap
     value = BigInt(Smi.max)
     self.mulEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // heap * smi
     value = BigInt(Word.max)
     self.mulEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
 
     // heap * heap
     value = BigInt(Word.max)
     self.mulEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func mulEqualSmi(toInout value: inout BigInt) {
@@ -422,54 +438,56 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_div_toCopy_doesNotModifyOriginal() {
+  @Test
+  func div_toCopy_doesNotModifyOriginal() {
     // smi / smi
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy / self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi / heap
     value = BigInt(Smi.max)
     copy = value
     _ = copy / self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap / smi
     value = BigInt(Word.max)
     copy = value
     _ = copy / self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap / heap
     value = BigInt(Word.max)
     copy = value
     _ = copy / self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_div_toInout_doesNotModifyOriginal() {
+  @Test
+  func div_toInout_doesNotModifyOriginal() {
     // smi / smi
     var value = BigInt(Smi.max)
     self.divSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi / heap
     value = BigInt(Smi.max)
     self.divHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap / smi
     value = BigInt(Word.max)
     self.divSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap / heap
     value = BigInt(Word.max)
     self.divHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func divSmi(toInout value: inout BigInt) {
@@ -480,52 +498,54 @@ class BigIntCOWTests: XCTestCase {
     _ = value / self.heapValue
   }
 
-  func test_divEqual_toCopy_doesNotModifyOriginal() {
+  @Test
+  func divEqual_toCopy_doesNotModifyOriginal() {
     // smi / smi
     var value = BigInt(Smi.max)
     var copy = value
     copy /= self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi / heap
     value = BigInt(Smi.max)
     copy = value
     copy /= self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap / smi
     value = BigInt(Word.max)
     copy = value
     copy /= self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap / heap
     value = BigInt(Word.max)
     copy = value
     copy /= self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_divEqual_toInout_doesModifyOriginal() {
+  @Test
+  func divEqual_toInout_doesModifyOriginal() {
     // smi / smi
     var value = BigInt(Smi.max)
     self.divEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // smi / heap
     value = BigInt(Smi.max)
     self.divEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // heap / smi
     value = BigInt(Word.max)
     self.divEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
 
     // heap / heap
     value = BigInt(Word.max)
     self.divEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func divEqualSmi(toInout value: inout BigInt) {
@@ -540,54 +560,56 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_mod_toCopy_doesNotModifyOriginal() {
+  @Test
+  func mod_toCopy_doesNotModifyOriginal() {
     // smi % smi
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy % self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi % heap
     value = BigInt(Smi.max)
     copy = value
     _ = copy % self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap % smi
     value = BigInt(Word.max)
     copy = value
     _ = copy % self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap % heap
     value = BigInt(Word.max)
     copy = value
     _ = copy % self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_mod_toInout_doesNotModifyOriginal() {
+  @Test
+  func mod_toInout_doesNotModifyOriginal() {
     // smi % smi
     var value = BigInt(Smi.max)
     self.modSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi % heap
     value = BigInt(Smi.max)
     self.modHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap % smi
     value = BigInt(Word.max)
     self.modSmi(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap % heap
     value = BigInt(Word.max)
     self.modHeap(toInout: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func modSmi(toInout value: inout BigInt) {
@@ -598,37 +620,39 @@ class BigIntCOWTests: XCTestCase {
     _ = value % self.heapValue
   }
 
-  func test_modEqual_toCopy_doesNotModifyOriginal() {
+  @Test
+  func modEqual_toCopy_doesNotModifyOriginal() {
     // smi % smi
     var value = BigInt(Smi.max)
     var copy = value
     copy %= self.smiValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // smi % heap
     value = BigInt(Smi.max)
     copy = value
     copy %= self.heapValue
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap % smi
     value = BigInt(Word.max)
     copy = value
     copy %= self.smiValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
 
     // heap % heap
     value = BigInt(Word.max)
     copy = value
     copy %= self.heapValue
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_modEqual_toInout_doesModifyOriginal() {
+  @Test
+  func modEqual_toInout_doesModifyOriginal() {
     // smi % smi
     var value = BigInt(Smi.max)
     self.modEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // smi % heap
     // 'heap' is always greater than 'smi', so modulo is actually equal to 'smi'
@@ -639,12 +663,12 @@ class BigIntCOWTests: XCTestCase {
     // heap % smi
     value = BigInt(Word.max)
     self.modEqualSmi(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
 
     // heap % heap
     value = BigInt(Word.max)
     self.modEqualHeap(toInout: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func modEqualSmi(toInout value: inout BigInt) {
@@ -659,62 +683,66 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_shiftLeft_copy_doesNotModifyOriginal() {
+  @Test
+  func shiftLeft_copy_doesNotModifyOriginal() {
     // smi << int
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy << self.shiftCount
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap << int
     value = BigInt(Word.max)
     copy = value
     _ = copy << self.shiftCount
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_shiftLeft_inout_doesNotModifyOriginal() {
+  @Test
+  func shiftLeft_inout_doesNotModifyOriginal() {
     // smi << int
     var value = BigInt(Smi.max)
     self.shiftLeft(value: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap << int
     value = BigInt(Word.max)
     self.shiftLeft(value: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func shiftLeft(value: inout BigInt) {
     _ = value << self.shiftCount
   }
 
-  func test_shiftLeftEqual_copy_doesNotModifyOriginal() {
+  @Test
+  func shiftLeftEqual_copy_doesNotModifyOriginal() {
     // smi << int
     var value = BigInt(Smi.max)
     var copy = value
     copy <<= self.shiftCount
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap << int
     value = BigInt(Word.max)
     copy = value
     copy <<= self.shiftCount
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_shiftLeftEqual_inout_doesModifyOriginal() {
+  @Test
+  func shiftLeftEqual_inout_doesModifyOriginal() {
     // smi << int
     var value = BigInt(Smi.max)
     self.shiftLeftEqual(value: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // heap << int
     value = BigInt(Word.max)
     self.shiftLeftEqual(value: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func shiftLeftEqual(value: inout BigInt) {
@@ -725,62 +753,66 @@ class BigIntCOWTests: XCTestCase {
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_shiftRight_copy_doesNotModifyOriginal() {
+  @Test
+  func shiftRight_copy_doesNotModifyOriginal() {
     // smi >> int
     var value = BigInt(Smi.max)
     var copy = value
     _ = copy >> self.shiftCount
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap >> int
     value = BigInt(Word.max)
     copy = value
     _ = copy >> self.shiftCount
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   /// This test actually DOES make sense, because, even though 'BigInt' is immutable,
   /// the heap that is points to is not.
-  func test_shiftRight_inout_doesNotModifyOriginal() {
+  @Test
+  func shiftRight_inout_doesNotModifyOriginal() {
     // smi >> int
     var value = BigInt(Smi.max)
     self.shiftRight(value: &value)
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap >> int
     value = BigInt(Word.max)
     self.shiftRight(value: &value)
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
   private func shiftRight(value: inout BigInt) {
     _ = value >> self.shiftCount
   }
 
-  func test_shiftRightEqual_copy_doesNotModifyOriginal() {
+  @Test
+  func shiftRightEqual_copy_doesNotModifyOriginal() {
     // smi >> int
     var value = BigInt(Smi.max)
     var copy = value
     copy >>= self.shiftCount
-    XCTAssertEqual(value, BigInt(Smi.max))
+    #expect(value == BigInt(Smi.max))
 
     // heap >> int
     value = BigInt(Word.max)
     copy = value
     copy >>= self.shiftCount
-    XCTAssertEqual(value, BigInt(Word.max))
+    #expect(value == BigInt(Word.max))
   }
 
-  func test_shiftRightEqual_inout_doesModifyOriginal() {
+  @Test
+  func shiftRightEqual_inout_doesModifyOriginal() {
     // smi >> int
     var value = BigInt(Smi.max)
     self.shiftRightEqual(value: &value)
-    XCTAssertNotEqual(value, BigInt(Smi.max))
+    #expect(value != BigInt(Smi.max))
 
     // heap >> int
     value = BigInt(Word.max)
     self.shiftRightEqual(value: &value)
-    XCTAssertNotEqual(value, BigInt(Word.max))
+    #expect(value != BigInt(Word.max))
   }
 
   private func shiftRightEqual(value: inout BigInt) {

--- a/Tests/BigIntTests/Violet/BigIntHashTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntHashTests.swift
@@ -1,17 +1,18 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 // Well… actually… hash and equatable
-class BigIntHashTests: XCTestCase {
+@Suite
+struct BigIntHashTests {
 
   private let smis = generateIntValues(countButNotReally: 50)
   private let heaps = generateBigIntValues(countButNotReally: 50)
 
   // Values that are in both `smis` and `heaps`.
-  private lazy var common: [BigInt] = {
+  private var common: [BigInt] {
     var result = [BigInt]()
     let smiSet = Set(self.smis)
 
@@ -23,9 +24,9 @@ class BigIntHashTests: XCTestCase {
     }
 
     return result
-  }()
+  }
 
-  private var scalars: [UnicodeScalar] = {
+  private let scalars: [UnicodeScalar] = {
     let asciiStart: UInt8 = 0x21 // !
     let asciiEnd: UInt8 = 0x7e // ~
     let result = (asciiStart...asciiEnd).map { UnicodeScalar($0) }
@@ -34,45 +35,47 @@ class BigIntHashTests: XCTestCase {
 
   // MARK: - Set
 
-  func test_set_insertAndFind() {
+  @Test
+  func set_insertAndFind() {
     // Insert all of the values
     var set = Set<BigInt>()
     self.insert(&set, values: self.smis)
     self.insert(&set, values: self.heaps)
 
     let expectedCount = self.smis.count + self.heaps.count - self.common.count
-    XCTAssertEqual(set.count, expectedCount)
+    #expect(set.count == expectedCount)
 
     // Check if we can find them
     for value in self.smis {
       let int = self.create(value)
-      XCTAssert(set.contains(int), "\(value)")
+      #expect(set.contains(int), "\(value)")
     }
 
     for value in self.heaps {
       let int = self.create(value)
-      XCTAssert(set.contains(int), "\(int)")
+      #expect(set.contains(int), "\(int)")
     }
   }
 
-  func test_set_insertAndRemove() {
+  @Test
+  func set_insertAndRemove() {
     // Insert all of the values
     var set = Set<BigInt>()
     self.insert(&set, values: self.smis)
     self.insert(&set, values: self.heaps)
 
     let allCount = self.smis.count + self.heaps.count - self.common.count
-    XCTAssertEqual(set.count, allCount)
+    #expect(set.count == allCount)
 
     // And now remove them
     for value in self.smis {
       let int = self.create(value)
       let existing = set.remove(int)
-      XCTAssertNotNil(existing, "Missing: \(value)")
+      #expect(existing != nil, "Missing: \(value)")
     }
 
     let withoutSmiCount = self.heaps.count - self.common.count
-    XCTAssertEqual(set.count, withoutSmiCount)
+    #expect(set.count == withoutSmiCount)
 
     for value in self.heaps {
       let int = self.create(value)
@@ -80,32 +83,33 @@ class BigIntHashTests: XCTestCase {
 
       if !wasAlreadyRemoved {
         let existing = set.remove(int)
-        XCTAssertNotNil(existing, "Missing: \(int)")
+        #expect(existing != nil, "Missing: \(int)")
       }
     }
 
-    XCTAssert(set.isEmpty)
+    #expect(set.isEmpty)
   }
 
   // MARK: - Dict
 
-  func test_dict_insertAndFind() {
+  @Test
+  func dict_insertAndFind() {
     // Insert all of the numbers to dict
     var dict = [BigInt: UnicodeScalar]()
     self.insert(&dict, values: zip(self.smis, self.scalars))
     self.insert(&dict, values: zip(self.heaps, self.scalars), excluding: self.common)
 
     let expectedCount = self.smis.count + self.heaps.count - self.common.count
-    XCTAssertEqual(dict.count, expectedCount)
+    #expect(dict.count == expectedCount)
 
     // Check if we can find all of the elements
     for (value, char) in zip(self.smis, self.scalars) {
       let int = self.create(value)
 
       if let result = dict[int] {
-        XCTAssertEqual(result, char, "key: \(int)")
+        #expect(result == char, "key: \(int)")
       } else {
-        XCTFail("missing: \(int)")
+        Issue.record("missing: \(int)")
       }
     }
 
@@ -115,31 +119,32 @@ class BigIntHashTests: XCTestCase {
       if self.common.contains(int) {
         // It was already checked in 'smi' loop
       } else if let result = dict[int] {
-        XCTAssertEqual(result, char, "key: \(int)")
+        #expect(result == char, "key: \(int)")
       } else {
-        XCTFail("missing: \(int)")
+        Issue.record("missing: \(int)")
       }
     }
   }
 
-  func test_dict_insertAndRemove() {
+  @Test
+  func dict_insertAndRemove() {
     // Insert all of the numbers to dict
     var dict = [BigInt: UnicodeScalar]()
     self.insert(&dict, values: zip(self.smis, self.scalars))
     self.insert(&dict, values: zip(self.heaps, self.scalars), excluding: self.common)
 
     let expectedCount = self.smis.count + self.heaps.count - self.common.count
-    XCTAssertEqual(dict.count, expectedCount)
+    #expect(dict.count == expectedCount)
 
     // And now remove them
     for value in self.smis {
       let int = self.create(value)
       let existing = dict.removeValue(forKey: int)
-      XCTAssertNotNil(existing, "Missing: \(value)")
+      #expect(existing != nil, "Missing: \(value)")
     }
 
     let withoutSmiCount = self.heaps.count - self.common.count
-    XCTAssertEqual(dict.count, withoutSmiCount)
+    #expect(dict.count == withoutSmiCount)
 
     for value in self.heaps {
       let int = self.create(value)
@@ -147,21 +152,22 @@ class BigIntHashTests: XCTestCase {
 
       if !wasAlreadyRemoved {
         let existing = dict.removeValue(forKey: int)
-        XCTAssertNotNil(existing, "Missing: \(int)")
+        #expect(existing != nil, "Missing: \(int)")
       }
     }
 
-    XCTAssert(dict.isEmpty)
+    #expect(dict.isEmpty)
   }
 
-  func test_dict_insertReplaceAndFind() {
+  @Test
+  func dict_insertReplaceAndFind() {
     // Insert all of the numbers to dict
     var dict = [BigInt: UnicodeScalar]()
     self.insert(&dict, values: zip(self.smis, self.scalars))
     self.insert(&dict, values: zip(self.heaps, self.scalars), excluding: self.common)
 
     let expectedCount = self.smis.count + self.heaps.count - self.common.count
-    XCTAssertEqual(dict.count, expectedCount)
+    #expect(dict.count == expectedCount)
 
     // Replace the values
     let reversedScalars = self.scalars.reversed()
@@ -169,16 +175,16 @@ class BigIntHashTests: XCTestCase {
     self.insert(&dict, values: zip(self.heaps, reversedScalars), excluding: self.common)
 
     // Count should have not changed
-    XCTAssertEqual(dict.count, expectedCount)
+    #expect(dict.count == expectedCount)
 
     // Check if we can find all of the elements
     for (value, char) in zip(self.smis, reversedScalars) {
       let int = self.create(value)
 
       if let result = dict[int] {
-        XCTAssertEqual(result, char, "key: \(int)")
+        #expect(result == char, "key: \(int)")
       } else {
-        XCTFail("missing: \(int)")
+        Issue.record("missing: \(int)")
       }
     }
 
@@ -188,9 +194,9 @@ class BigIntHashTests: XCTestCase {
       if self.common.contains(int) {
         // It was already checked in 'smi' loop
       } else if let result = dict[int] {
-        XCTAssertEqual(result, char, "key: \(int)")
+        #expect(result == char, "key: \(int)")
       } else {
-        XCTFail("missing: \(int)")
+        Issue.record("missing: \(int)")
       }
     }
   }

--- a/Tests/BigIntTests/Violet/BigIntIntegerInitTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntIntegerInitTests.swift
@@ -33,9 +33,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func exactly_inRange<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     var values: [T] = [0, 42, T.max, T.max - 1, T.min, T.min + 1]
     values.append(contentsOf: allPositivePowersOf2(type: T.self).map { $0.value })
@@ -86,9 +84,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func exactly_biggerThanMax<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     let max = type.max
 
@@ -120,9 +116,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func exactly_lessThanMin<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     let min = type.min
 
@@ -156,9 +150,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func clamping_inRange<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
 
     var values: [T] = [0, 42, T.max, T.max - 1, T.min, T.min + 1]
@@ -207,9 +199,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func clamping_biggerThanMax<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     let maxT = type.max
     let max = BigInt(maxT)
@@ -250,9 +240,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func clamping_lessThanMin<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     let minT = type.min
     let min = BigInt(minT)
@@ -295,9 +283,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func truncatingIfNeeded_inRange<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
 
     var values: [T] = [0, 42, T.max, T.max - 1, T.min, T.min + 1]
@@ -346,9 +332,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func truncatingIfNeeded_biggerThanMax<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     let maxT = type.max
     let max = BigInt(maxT)
@@ -399,9 +383,7 @@ struct BigIntIntegerInitTests {
   }
 
   private func truncatingIfNeeded_lessThanMin<T: FixedWidthInteger>(
-    type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
+    type: T.Type
   ) {
     let maxT = type.max
     let max = BigInt(maxT)

--- a/Tests/BigIntTests/Violet/BigIntIntegerInitTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntIntegerInitTests.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 private typealias Word = BigInt.Word
@@ -9,11 +9,13 @@ private typealias Word = BigInt.Word
 /// This class tests `BigInt -> Swift.Integer` inits!
 /// Our `BigInt.inits` are quite trivial (because we can represent any number),
 /// so we will not test them.
-class BigIntIntegerInitTests: XCTestCase {
+@Suite
+struct BigIntIntegerInitTests {
 
   // MARK: - Exactly
 
-  func test_exactly_signed() {
+  @Test
+  func exactly_signed() {
     self.exactly_inRange(type: Int8.self)
     self.exactly_inRange(type: Int16.self)
     self.exactly_inRange(type: Int32.self)
@@ -21,7 +23,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.exactly_inRange(type: Int.self)
   }
 
-  func test_exactly_unsigned() {
+  @Test
+  func exactly_unsigned() {
     self.exactly_inRange(type: UInt8.self)
     self.exactly_inRange(type: UInt16.self)
     self.exactly_inRange(type: UInt32.self)
@@ -53,19 +56,19 @@ class BigIntIntegerInitTests: XCTestCase {
       // String representation should be equal - trivial test for value
       let bigIntString = String(bigInt, radix: 10, uppercase: false)
       let valueString = String(value, radix: 10, uppercase: false)
-      XCTAssertEqual(bigIntString, valueString, "\(header) - String", file: file, line: line)
+      #expect(bigIntString == valueString, "\(header) - String")
 
       // T -> BigInt -> T
       if let revert = T(exactly: bigInt) {
-        let msg = "\(header) - \(typeName) -> BigInt -> \(typeName)"
-        XCTAssertEqual(value, revert, msg, file: file, line: line)
+        #expect(value == revert, "\(header) - \(typeName) -> BigInt -> \(typeName)")
       } else {
-        XCTFail("\(header) - failed BigInt -> \(typeName)", file: file, line: line)
+        Issue.record("\(header) - failed BigInt -> \(typeName)")
       }
     }
   }
 
-  func test_exactly_signed_biggerThanMax_returnsNil() {
+  @Test
+  func exactly_signed_biggerThanMax_returnsNil() {
     self.exactly_biggerThanMax(type: Int8.self)
     self.exactly_biggerThanMax(type: Int16.self)
     self.exactly_biggerThanMax(type: Int32.self)
@@ -73,7 +76,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.exactly_biggerThanMax(type: Int.self)
   }
 
-  func test_exactly_unsigned_biggerThanMax_returnsNil() {
+  @Test
+  func exactly_unsigned_biggerThanMax_returnsNil() {
     self.exactly_biggerThanMax(type: UInt8.self)
     self.exactly_biggerThanMax(type: UInt16.self)
     self.exactly_biggerThanMax(type: UInt32.self)
@@ -90,14 +94,15 @@ class BigIntIntegerInitTests: XCTestCase {
 
     var maxPlus1 = BigInt(max)
     maxPlus1 += 1
-    XCTAssertNil(T(exactly: maxPlus1), "\(max) + 1", file: file, line: line)
+    #expect(T(exactly: maxPlus1) == nil, "\(max) + 1")
 
     let moreWordsHeap = BigIntPrototype(isNegative: false, words: [0, 1])
     let moreWords = moreWordsHeap.create()
-    XCTAssertNil(T(exactly: moreWords), "\(moreWordsHeap)", file: file, line: line)
+    #expect(T(exactly: moreWords) == nil, "\(moreWordsHeap)")
   }
 
-  func test_exactly_signed_lessThanMin_returnsNil() {
+  @Test
+  func exactly_signed_lessThanMin_returnsNil() {
     self.exactly_lessThanMin(type: Int8.self)
     self.exactly_lessThanMin(type: Int16.self)
     self.exactly_lessThanMin(type: Int32.self)
@@ -105,7 +110,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.exactly_lessThanMin(type: Int.self)
   }
 
-  func test_exactly_unsigned_lessThanMin_returnsNil() {
+  @Test
+  func exactly_unsigned_lessThanMin_returnsNil() {
     self.exactly_lessThanMin(type: UInt8.self)
     self.exactly_lessThanMin(type: UInt16.self)
     self.exactly_lessThanMin(type: UInt32.self)
@@ -122,16 +128,17 @@ class BigIntIntegerInitTests: XCTestCase {
 
     var minMinus1 = BigInt(min)
     minMinus1 -= 1
-    XCTAssertNil(T(exactly: minMinus1), "\(min) - 1", file: file, line: line)
+    #expect(T(exactly: minMinus1) == nil, "\(min) - 1")
 
     let moreWordsHeap = BigIntPrototype(isNegative: true, words: [0, 1])
     let moreWords = moreWordsHeap.create()
-    XCTAssertNil(T(exactly: moreWords), "\(moreWordsHeap)", file: file, line: line)
+    #expect(T(exactly: moreWords) == nil, "\(moreWordsHeap)")
   }
 
   // MARK: - Clamping
 
-  func test_clamping_signed() {
+  @Test
+  func clamping_signed() {
     self.clamping_inRange(type: Int8.self)
     self.clamping_inRange(type: Int16.self)
     self.clamping_inRange(type: Int32.self)
@@ -139,7 +146,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.clamping_inRange(type: Int.self)
   }
 
-  func test_clamping_unsigned() {
+  @Test
+  func clamping_unsigned() {
     self.clamping_inRange(type: UInt8.self)
     self.clamping_inRange(type: UInt16.self)
     self.clamping_inRange(type: UInt32.self)
@@ -172,16 +180,16 @@ class BigIntIntegerInitTests: XCTestCase {
       // String representation should be equal - trivial test for value
       let bigIntString = String(bigInt, radix: 10, uppercase: false)
       let valueString = String(value, radix: 10, uppercase: false)
-      XCTAssertEqual(bigIntString, valueString, "\(header) - String", file: file, line: line)
+      #expect(bigIntString == valueString, "\(header) - String")
 
       // T -> BigInt -> T
       let revert = T(clamping: bigInt)
-      let msg = "\(header) - \(typeName) -> BigInt -> \(typeName)"
-      XCTAssertEqual(value, revert, msg, file: file, line: line)
+      #expect(value == revert, "\(header) - \(typeName) -> BigInt -> \(typeName)")
     }
   }
 
-  func test_clamping_signed_biggerThanMax_returnsNil() {
+  @Test
+  func clamping_signed_biggerThanMax_returnsNil() {
     self.clamping_biggerThanMax(type: Int8.self)
     self.clamping_biggerThanMax(type: Int16.self)
     self.clamping_biggerThanMax(type: Int32.self)
@@ -189,7 +197,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.clamping_biggerThanMax(type: Int.self)
   }
 
-  func test_clamping_unsigned_biggerThanMax_returnsNil() {
+  @Test
+  func clamping_unsigned_biggerThanMax_returnsNil() {
     self.clamping_biggerThanMax(type: UInt8.self)
     self.clamping_biggerThanMax(type: UInt16.self)
     self.clamping_biggerThanMax(type: UInt32.self)
@@ -209,7 +218,7 @@ class BigIntIntegerInitTests: XCTestCase {
       let maxPlus1 = max + 1
       let clamped = T(clamping: maxPlus1)
       let clampedBigInt = BigInt(clamped)
-      XCTAssertEqual(clampedBigInt, max, "\(max) + 1", file: file, line: line)
+      #expect(clampedBigInt == max, "\(max) + 1")
     }
 
     do {
@@ -218,11 +227,12 @@ class BigIntIntegerInitTests: XCTestCase {
 
       let clamped = T(clamping: moreWords)
       let clampedBigInt = BigInt(clamped)
-      XCTAssertEqual(clampedBigInt, max, "\(moreWordsHeap)", file: file, line: line)
+      #expect(clampedBigInt == max, "\(moreWordsHeap)")
     }
   }
 
-  func test_clamping_signed_lessThanMin_returnsNil() {
+  @Test
+  func clamping_signed_lessThanMin_returnsNil() {
     self.clamping_lessThanMin(type: Int8.self)
     self.clamping_lessThanMin(type: Int16.self)
     self.clamping_lessThanMin(type: Int32.self)
@@ -230,7 +240,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.clamping_lessThanMin(type: Int.self)
   }
 
-  func test_clamping_unsigned_lessThanMin_returnsNil() {
+  @Test
+  func clamping_unsigned_lessThanMin_returnsNil() {
     self.clamping_lessThanMin(type: UInt8.self)
     self.clamping_lessThanMin(type: UInt16.self)
     self.clamping_lessThanMin(type: UInt32.self)
@@ -250,7 +261,7 @@ class BigIntIntegerInitTests: XCTestCase {
       let minMinus1 = min - 1
       let clamped = T(clamping: minMinus1)
       let clampedBigInt = BigInt(clamped)
-      XCTAssertEqual(clampedBigInt, min, "\(min) - 1", file: file, line: line)
+      #expect(clampedBigInt == min, "\(min) - 1")
     }
 
     do {
@@ -259,13 +270,14 @@ class BigIntIntegerInitTests: XCTestCase {
 
       let clamped = T(clamping: moreWords)
       let clampedBigInt = BigInt(clamped)
-      XCTAssertEqual(clampedBigInt, min, "\(moreWordsHeap)", file: file, line: line)
+      #expect(clampedBigInt == min, "\(moreWordsHeap)")
     }
   }
 
   // MARK: - Truncating if needed
 
-  func test_truncatingIfNeeded_signed() {
+  @Test
+  func truncatingIfNeeded_signed() {
     self.truncatingIfNeeded_inRange(type: Int8.self)
     self.truncatingIfNeeded_inRange(type: Int16.self)
     self.truncatingIfNeeded_inRange(type: Int32.self)
@@ -273,7 +285,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.truncatingIfNeeded_inRange(type: Int.self)
   }
 
-  func test_truncatingIfNeeded_unsigned() {
+  @Test
+  func truncatingIfNeeded_unsigned() {
     self.truncatingIfNeeded_inRange(type: UInt8.self)
     self.truncatingIfNeeded_inRange(type: UInt16.self)
     self.truncatingIfNeeded_inRange(type: UInt32.self)
@@ -306,16 +319,16 @@ class BigIntIntegerInitTests: XCTestCase {
       // String representation should be equal - trivial test for value
       let bigIntString = String(bigInt, radix: 10, uppercase: false)
       let valueString = String(value, radix: 10, uppercase: false)
-      XCTAssertEqual(bigIntString, valueString, "\(header) - String", file: file, line: line)
+      #expect(bigIntString == valueString, "\(header) - String")
 
       // T -> BigInt -> T
       let revert = T(truncatingIfNeeded: bigInt)
-      let msg = "\(header) - \(typeName) -> BigInt -> \(typeName)"
-      XCTAssertEqual(value, revert, msg, file: file, line: line)
+      #expect(value == revert, "\(header) - \(typeName) -> BigInt -> \(typeName)")
     }
   }
 
-  func test_truncatingIfNeeded_signed_biggerThanMax_returnsNil() {
+  @Test
+  func truncatingIfNeeded_signed_biggerThanMax_returnsNil() {
     self.truncatingIfNeeded_biggerThanMax(type: Int8.self)
     self.truncatingIfNeeded_biggerThanMax(type: Int16.self)
     self.truncatingIfNeeded_biggerThanMax(type: Int32.self)
@@ -323,7 +336,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.truncatingIfNeeded_biggerThanMax(type: Int.self)
   }
 
-  func test_truncatingIfNeeded_unsigned_biggerThanMax_returnsNil() {
+  @Test
+  func truncatingIfNeeded_unsigned_biggerThanMax_returnsNil() {
     self.truncatingIfNeeded_biggerThanMax(type: UInt8.self)
     self.truncatingIfNeeded_biggerThanMax(type: UInt16.self)
     self.truncatingIfNeeded_biggerThanMax(type: UInt32.self)
@@ -350,7 +364,7 @@ class BigIntIntegerInitTests: XCTestCase {
       let truncatedBigInt = BigInt(truncated)
 
       let expected = T.isSigned ? min : zero
-      XCTAssertEqual(truncatedBigInt, expected, "\(max) + 1", file: file, line: line)
+      #expect(truncatedBigInt == expected, "\(max) + 1")
     }
 
     do {
@@ -362,11 +376,12 @@ class BigIntIntegerInitTests: XCTestCase {
       let truncatedBigInt = BigInt(truncated)
 
       let expected = BigInt(lowWord)
-      XCTAssertEqual(truncatedBigInt, expected, "\(moreWordsHeap)", file: file, line: line)
+      #expect(truncatedBigInt == expected, "\(moreWordsHeap)")
     }
   }
 
-  func test_truncatingIfNeeded_signed_lessThanMin_returnsNil() {
+  @Test
+  func truncatingIfNeeded_signed_lessThanMin_returnsNil() {
     self.truncatingIfNeeded_lessThanMin(type: Int8.self)
     self.truncatingIfNeeded_lessThanMin(type: Int16.self)
     self.truncatingIfNeeded_lessThanMin(type: Int32.self)
@@ -374,7 +389,8 @@ class BigIntIntegerInitTests: XCTestCase {
     self.truncatingIfNeeded_lessThanMin(type: Int.self)
   }
 
-  func test_truncatingIfNeeded_unsigned_lessThanMin_returnsNil() {
+  @Test
+  func truncatingIfNeeded_unsigned_lessThanMin_returnsNil() {
     self.truncatingIfNeeded_lessThanMin(type: UInt8.self)
     self.truncatingIfNeeded_lessThanMin(type: UInt16.self)
     self.truncatingIfNeeded_lessThanMin(type: UInt32.self)
@@ -400,7 +416,7 @@ class BigIntIntegerInitTests: XCTestCase {
       let truncatedBigInt = BigInt(truncated)
 
       let expected = max
-      XCTAssertEqual(truncatedBigInt, expected, "\(min) - 1", file: file, line: line)
+      #expect(truncatedBigInt == expected, "\(min) - 1")
     }
 
     do {
@@ -416,7 +432,7 @@ class BigIntIntegerInitTests: XCTestCase {
 
       let complement = ~lowWord + 1 // no overflow possible
       let expected = BigInt(T(truncatingIfNeeded: complement))
-      XCTAssertEqual(truncatedBigInt, expected, "\(moreWordsHeap)", file: file, line: line)
+      #expect(truncatedBigInt == expected, "\(moreWordsHeap)")
     }
   }
 }

--- a/Tests/BigIntTests/Violet/BigIntPowerTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntPowerTests.swift
@@ -1,10 +1,12 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
+import Foundation
 
-class BigIntPowerTests: XCTestCase {
+@Suite
+struct BigIntPowerTests {
 
   // MARK: - Trivial base
 
@@ -23,18 +25,20 @@ class BigIntPowerTests: XCTestCase {
 //  }
 
   /// 1 ^ n = 1
-  func test_base_one() {
+  @Test
+  func base_one() {
     let one = BigInt(1)
 
     for exponent in generateIntValues(countButNotReally: 100) {
       let result = one.power(exponent)
       let expected = one
-      XCTAssertEqual(result, expected, "1 ^ \(exponent)")
+      #expect(result == expected, "1 ^ \(exponent)")
     }
   }
 
   /// (-1) ^ n = (-1) or 1
-  func test_base_minusOne() {
+  @Test
+  func base_minusOne() {
     let plusOne = BigInt(1)
     let minusOne = BigInt(-1)
 
@@ -42,14 +46,15 @@ class BigIntPowerTests: XCTestCase {
       let result = minusOne.power(exponent)
 
       let expected = exponent.isMultiple(of: 2) ? plusOne : minusOne
-      XCTAssertEqual(result, expected, "(-1) ^ \(exponent)")
+      #expect(result == expected, "(-1) ^ \(exponent)")
     }
   }
 
   // MARK: - Trivial exponent
 
   /// n ^ 0 = 1
-  func test_exponent_zero() {
+  @Test
+  func exponent_zero() {
     let zero = 0
     let one = BigInt(1)
 
@@ -58,12 +63,13 @@ class BigIntPowerTests: XCTestCase {
       let result = base.power(zero)
 
       let expected = one
-      XCTAssertEqual(result, expected, "\(smi) ^ 1")
+      #expect(result == expected, "\(smi) ^ 1")
     }
   }
 
   /// n ^ 1 = n
-  func test_exponent_one() {
+  @Test
+  func exponent_one() {
     let one = 1
 
     for smi in generateIntValues(countButNotReally: 100) {
@@ -71,11 +77,12 @@ class BigIntPowerTests: XCTestCase {
       let result = base.power(one)
 
       let expected = base
-      XCTAssertEqual(result, expected, "\(smi) ^ 1")
+      #expect(result == expected, "\(smi) ^ 1")
     }
   }
 
-  func test_exponent_two() {
+  @Test
+  func exponent_two() {
     let two = 2
 
     for p in generateBigIntValues(countButNotReally: 2) {
@@ -84,11 +91,12 @@ class BigIntPowerTests: XCTestCase {
       let result = base.power(two)
 
       let expected = base * base
-      XCTAssertEqual(result, expected, "\(base) ^ 2")
+      #expect(result == expected, "\(base) ^ 2")
     }
   }
 
-  func test_exponent_three() {
+  @Test
+  func exponent_three() {
     let three = 3
 
     for p in generateBigIntValues(countButNotReally: 2) {
@@ -97,13 +105,14 @@ class BigIntPowerTests: XCTestCase {
       let result = base.power(three)
 
       let expected = base * base * base
-      XCTAssertEqual(result, expected, "\(base) ^ 3")
+      #expect(result == expected, "\(base) ^ 3")
     }
   }
 
   // MARK: - Smi
 
-  func test_againstFoundationPow() {
+  @Test
+  func againstFoundationPow() {
     // THIS IS NOT A PERFECT TEST!
     // It is 'good enough' to be usable, but don't think about it too much!
     let mantissaCount = Double.significandBitCount // well… technically '+1'
@@ -127,7 +136,7 @@ class BigIntPowerTests: XCTestCase {
 
       guard let baseDouble = Double(exactly: baseSmi),
             let expDouble = Double(exactly: expSmi) else {
-          continue
+        continue
       }
 
       let expectedDouble = pow(baseDouble, expDouble)
@@ -142,7 +151,7 @@ class BigIntPowerTests: XCTestCase {
       let result = base.power(exp)
 
       let expected = BigInt(expectedInt)
-      XCTAssertEqual(result, expected, "\(baseSmi) ^ \(expSmi)")
+      #expect(result == expected, "\(baseSmi) ^ \(expSmi)")
     }
   }
 }

--- a/Tests/BigIntTests/Violet/BigIntPropertyTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntPropertyTests.swift
@@ -1,19 +1,21 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 private typealias Word = BigInt.Word
 
-class BigIntPropertyTests: XCTestCase {
+@Suite
+struct BigIntPropertyTests {
 
   // MARK: - Description
 
-  func test_description() {
+  @Test
+  func description() {
     for int in generateIntValues(countButNotReally: 100) {
       let value = BigInt(int)
-      XCTAssertEqual(value.description, int.description, "\(int)")
+      #expect(value.description == int.description, "\(int)")
     }
   }
 
@@ -31,7 +33,8 @@ class BigIntPropertyTests: XCTestCase {
 //    }
 //  }
 
-  func test_words_multipleWords_positive() {
+  @Test
+  func words_multipleWords_positive() {
     for (words, expected) in WordsTestCases.heapPositive {
       let heap = BigIntPrototype(isNegative: false, words: words)
       let bigInt = heap.create()
@@ -47,7 +50,8 @@ class BigIntPropertyTests: XCTestCase {
 //    }
 //  }
 
-  func test_words_multipleWords_negative_notPowerOf2() {
+  @Test
+  func words_multipleWords_negative_notPowerOf2() {
     for (words, expected) in WordsTestCases.heapNegative_notPowerOf2 {
       let heap = BigIntPrototype(isNegative: true, words: words)
       let bigInt = heap.create()
@@ -68,10 +72,11 @@ class BigIntPropertyTests: XCTestCase {
 //    XCTAssertEqual(minus1.bitWidth, 1) // -1 is just 1
 //  }
 
-  func test_bitWidth_positivePowersOf2() {
+  @Test
+  func bitWidth_positivePowersOf2() {
     for (int, power, expected) in BitWidthTestCases.positivePowersOf2 {
       let bigInt = BigInt(int)
-      XCTAssertEqual(bigInt.bitWidth, expected, "for \(int) (2^\(power))")
+      #expect(bigInt.bitWidth == expected, "for \(int) (2^\(power))")
     }
   }
 
@@ -89,7 +94,8 @@ class BigIntPropertyTests: XCTestCase {
 //    }
 //  }
 
-  func test_bitWidth_multipleWords_positivePowersOf2() {
+  @Test
+  func bitWidth_multipleWords_positivePowersOf2() {
     let correction = BitWidthTestCases.positivePowersOf2Correction
 
     for zeroWordCount in [1, 2] {
@@ -102,7 +108,7 @@ class BigIntPropertyTests: XCTestCase {
         let bigInt = heap.create()
 
         let expected = power + correction + zeroWordsBitWidth
-        XCTAssertEqual(bigInt.bitWidth, expected, "\(heap)")
+        #expect(bigInt.bitWidth == expected, "\(heap)")
       }
     }
   }
@@ -127,12 +133,14 @@ class BigIntPropertyTests: XCTestCase {
 
   // MARK: - Trailing zero bit count
 
-  func test_trailingZeroBitCount_zero() {
+  @Test
+  func trailingZeroBitCount_zero() {
     let zero = BigInt(0)
-    XCTAssertEqual(zero.trailingZeroBitCount, 0)
+    #expect(zero.trailingZeroBitCount == 0)
   }
 
-  func test_trailingZeroBitCount_int() {
+  @Test
+  func trailingZeroBitCount_int() {
     for raw in generateIntValues(countButNotReally: 100) {
       if raw == 0 {
         continue
@@ -142,11 +150,12 @@ class BigIntPropertyTests: XCTestCase {
       let result = int.trailingZeroBitCount
 
       let expected = raw.trailingZeroBitCount
-      XCTAssertEqual(result, expected)
+      #expect(result == expected)
     }
   }
 
-  func test_trailingZeroBitCount_heap_nonZeroFirstWord() {
+  @Test
+  func trailingZeroBitCount_heap_nonZeroFirstWord() {
     for p in generateBigIntValues(countButNotReally: 100, maxWordCount: 3) {
       if p.isZero {
         continue
@@ -161,11 +170,12 @@ class BigIntPropertyTests: XCTestCase {
       let result = int.trailingZeroBitCount
 
       let expected = p.words[0].trailingZeroBitCount
-      XCTAssertEqual(result, expected)
+      #expect(result == expected)
     }
   }
 
-  func test_trailingZeroBitCount_heap_zeroFirstWord() {
+  @Test
+  func trailingZeroBitCount_heap_zeroFirstWord() {
     for p in generateBigIntValues(countButNotReally: 100, maxWordCount: 3) {
       if p.isZero {
         continue
@@ -183,23 +193,25 @@ class BigIntPropertyTests: XCTestCase {
       let result = int.trailingZeroBitCount
 
       let expected = Word.bitWidth + p.words[1].trailingZeroBitCount
-      XCTAssertEqual(result, expected)
+      #expect(result == expected)
     }
   }
 
   // MARK: - Magnitude
 
-  func test_magnitude_int() {
+  @Test
+  func magnitude_int() {
     for raw in generateIntValues(countButNotReally: 100) {
       let int = BigInt(raw)
       let magnitude = int.magnitude
 
       let expected = raw.magnitude
-      XCTAssert(magnitude == expected, "\(raw)")
+      #expect(magnitude == expected, "\(raw)")
     }
   }
 
-  func test_magnitude_heap() {
+  @Test
+  func magnitude_heap() {
     for p in generateBigIntValues(countButNotReally: 100) {
       if p.isZero {
         continue
@@ -211,7 +223,7 @@ class BigIntPropertyTests: XCTestCase {
       let negativeHeap = BigIntPrototype(isNegative: true, words: p.words)
       let negative = negativeHeap.create()
 
-      XCTAssertEqual(positive.magnitude, negative.magnitude)
+      #expect(positive.magnitude == negative.magnitude)
     }
   }
 }

--- a/Tests/BigIntTests/Violet/BigIntPropertyTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntPropertyTests.swift
@@ -23,13 +23,13 @@ struct BigIntPropertyTests {
 
 //  func test_words_zero() {
 //    let value = BigInt(0)
-//    XCTAssertWords(value, WordsTestCases.zeroWords)
+//    expectWords(value, WordsTestCases.zeroWords)
 //  }
 //
 //  func test_words_int() {
 //    for (value, expected) in WordsTestCases.int {
 //      let bigInt = BigInt(value)
-//      XCTAssertWords(bigInt, expected)
+//      expectWords(bigInt, expected)
 //    }
 //  }
 
@@ -38,7 +38,7 @@ struct BigIntPropertyTests {
     for (words, expected) in WordsTestCases.heapPositive {
       let heap = BigIntPrototype(isNegative: false, words: words)
       let bigInt = heap.create()
-      XCTAssertWords(bigInt, expected)
+      expectWords(bigInt, expected)
     }
   }
 
@@ -46,7 +46,7 @@ struct BigIntPropertyTests {
 //    for (words, expected) in WordsTestCases.heapNegative_powerOf2 {
 //      let heap = BigIntPrototype(isNegative: true, words: words)
 //      let bigInt = heap.create()
-//      XCTAssertWords(bigInt, expected)
+//      expectWords(bigInt, expected)
 //    }
 //  }
 
@@ -55,7 +55,7 @@ struct BigIntPropertyTests {
     for (words, expected) in WordsTestCases.heapNegative_notPowerOf2 {
       let heap = BigIntPrototype(isNegative: true, words: words)
       let bigInt = heap.create()
-      XCTAssertWords(bigInt, expected)
+      expectWords(bigInt, expected)
     }
   }
 

--- a/Tests/BigIntTests/Violet/BigIntStringInitTests.swift
+++ b/Tests/BigIntTests/Violet/BigIntStringInitTests.swift
@@ -1,7 +1,7 @@
 // This file was written by LiarPrincess for Violet - Python VM written in Swift.
 // https://github.com/LiarPrincess/Violet
 
-import XCTest
+import Testing
 @testable import BigInt
 
 private typealias Word = BigInt.Word
@@ -14,73 +14,82 @@ private typealias OctalTestCases = StringTestCases.Octal
 private typealias DecimalTestCases = StringTestCases.Decimal
 private typealias HexTestCases = StringTestCases.Hex
 
-class BigIntStringInitTests: XCTestCase {
+@Suite
+struct BigIntStringInitTests {
 
   // MARK: - Empty
 
-  func test_empty_fails() {
+  @Test
+  func empty_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_onlyPlusSign_withoutDigits_fails() {
+  @Test
+  func onlyPlusSign_withoutDigits_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "+", radix: 10)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_onlyMinusSign_withoutDigits_fails() {
+  @Test
+  func onlyMinusSign_withoutDigits_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "-", radix: 10)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
   // MARK: - Zero
 
-  func test_zero_single() {
+  @Test
+  func zero_single() {
     let zero = BigInt()
 
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "0", radix: radix)
-      XCTAssertEqual(result, zero)
+      #expect(result == zero)
     }
   }
 
-  func test_zero_single_plus() {
+  @Test
+  func zero_single_plus() {
     let zero = BigInt()
 
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "+0", radix: radix)
-      XCTAssertEqual(result, zero)
+      #expect(result == zero)
     }
   }
 
-  func test_zero_single_minus() {
+  @Test
+  func zero_single_minus() {
     let zero = BigInt()
 
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "-0", radix: radix)
-      XCTAssertEqual(result, zero)
+      #expect(result == zero)
     }
   }
 
-  func test_zero_multiple() {
+  @Test
+  func zero_multiple() {
     let zero = BigInt()
     let input = String(repeating: "0", count: 42)
 
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: input, radix: radix)
-      XCTAssertEqual(result, zero)
+      #expect(result == zero)
     }
   }
 
   // MARK: - Smi
 
-  func test_smi_decimal() {
+  @Test
+  func smi_decimal() {
     let radix = 10
 
     for smi in generateIntValues(countButNotReally: 100) {
@@ -88,24 +97,26 @@ class BigIntStringInitTests: XCTestCase {
 
       let lowercase = String(smi, radix: radix, uppercase: false)
       let lowercaseResult = self.create(string: lowercase, radix: radix)
-      XCTAssertEqual(lowercaseResult, expected)
+      #expect(lowercaseResult == expected)
 
       let uppercase = String(smi, radix: radix, uppercase: true)
       let uppercaseResult = self.create(string: uppercase, radix: radix)
-      XCTAssertEqual(uppercaseResult, expected)
+      #expect(uppercaseResult == expected)
     }
   }
 
   // MARK: - Binary
 
-  func test_binary_singleWord() {
+  @Test
+  func binary_singleWord() {
     self.run(
       cases: BinaryTestCases.singleWord,
       radix: 2
     )
   }
 
-  func test_binary_twoWords() {
+  @Test
+  func binary_twoWords() {
     self.run(
       cases: BinaryTestCases.twoWords,
       radix: 2
@@ -114,14 +125,16 @@ class BigIntStringInitTests: XCTestCase {
 
   // MARK: - Quinary
 
-  func test_quinary_singleWord() {
+  @Test
+  func quinary_singleWord() {
     self.run(
       cases: QuinaryTestCases.singleWord,
       radix: 5
     )
   }
 
-  func test_quinary_twoWords() {
+  @Test
+  func quinary_twoWords() {
     self.run(
       cases: QuinaryTestCases.twoWords,
       radix: 5
@@ -130,21 +143,24 @@ class BigIntStringInitTests: XCTestCase {
 
   // MARK: - Octal
 
-  func test_octal_singleWord() {
+  @Test
+  func octal_singleWord() {
     self.run(
       cases: OctalTestCases.singleWord,
       radix: 8
     )
   }
 
-  func test_octal_twoWords() {
+  @Test
+  func octal_twoWords() {
     self.run(
       cases: OctalTestCases.twoWords,
       radix: 8
     )
   }
 
-  func test_octal_threeWords() {
+  @Test
+  func octal_threeWords() {
     self.run(
       cases: OctalTestCases.threeWords,
       radix: 8
@@ -153,28 +169,32 @@ class BigIntStringInitTests: XCTestCase {
 
   // MARK: - Decimal
 
-  func test_decimal_singleWord() {
+  @Test
+  func decimal_singleWord() {
     self.run(
       cases: DecimalTestCases.singleWord,
       radix: 10
     )
   }
 
-  func test_decimal_twoWords() {
+  @Test
+  func decimal_twoWords() {
     self.run(
       cases: DecimalTestCases.twoWords,
       radix: 10
     )
   }
 
-  func test_decimal_threeWords() {
+  @Test
+  func decimal_threeWords() {
     self.run(
       cases: DecimalTestCases.threeWords,
       radix: 10
     )
   }
 
-  func test_decimal_fourWords() {
+  @Test
+  func decimal_fourWords() {
     self.run(
       cases: DecimalTestCases.fourWords,
       radix: 10
@@ -183,21 +203,24 @@ class BigIntStringInitTests: XCTestCase {
 
   // MARK: - Hex
 
-  func test_hex_singleWord() {
+  @Test
+  func hex_singleWord() {
     self.run(
       cases: HexTestCases.singleWord,
       radix: 16
     )
   }
 
-  func test_hex_twoWords() {
+  @Test
+  func hex_twoWords() {
     self.run(
       cases: HexTestCases.twoWords,
       radix: 16
     )
   }
 
-  func test_hex_threeWords() {
+  @Test
+  func hex_threeWords() {
     self.run(
       cases: HexTestCases.threeWords,
       radix: 16
@@ -258,67 +281,76 @@ class BigIntStringInitTests: XCTestCase {
     return result
   }
 
-  func test_underscore_prefix_withoutSign_fails() {
+  @Test
+  func underscore_prefix_withoutSign_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "_0101", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_underscore_before_plusSign_fails() {
+  @Test
+  func underscore_before_plusSign_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "_+0101", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_underscore_before_minusSign_fails() {
+  @Test
+  func underscore_before_minusSign_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "_+0101", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_underscore_after_plusSign_fails() {
+  @Test
+  func underscore_after_plusSign_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "+_0101", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_underscore_after_minusSign_fails() {
+  @Test
+  func underscore_after_minusSign_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "-_0101", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_underscore_suffix_fails() {
+  @Test
+  func underscore_suffix_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "0101_", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_underscore_double_fails() {
+  @Test
+  func underscore_double_fails() {
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "01__01", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
   // MARK: - Invalid digit
 
-  func test_invalidDigit_emoji_fails() {
+  @Test
+  func invalidDigit_emoji_fails() {
     let emoji = "😊"
 
     for radix in [2, 4, 7, 32] {
       let result = self.create(string: "01\(emoji)01", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
-  func test_invalidDigit_biggerThanRadix_fails() {
+  @Test
+  func invalidDigit_biggerThanRadix_fails() {
     let cases: [(Int, UnicodeScalar)] = [
       (2, "2"),
       (4, "4"),
@@ -329,7 +361,7 @@ class BigIntStringInitTests: XCTestCase {
 
     for (radix, biggerThanRadix) in cases {
       let result = self.create(string: "01\(biggerThanRadix)01", radix: radix)
-      XCTAssertNil(result, "Radix: \(radix)")
+      #expect(result == nil, "Radix: \(radix)")
     }
   }
 
@@ -341,16 +373,14 @@ class BigIntStringInitTests: XCTestCase {
   }
 
   private func run(cases: [StringTestCases.TestCase],
-                   radix: Int,
-                   file: StaticString = #file,
-                   line: UInt = #line) {
+                   radix: Int) {
     for (words, input) in cases {
       // lowercased
       do {
         let result = self.create(string: input.lowercased(), radix: radix)
         let heap = BigIntPrototype(isNegative: false, words: words)
         let expected = heap.create()
-        XCTAssertEqual(result, expected, input, file: file, line: line)
+        #expect(result == expected, Comment(rawValue: input))
       }
 
       // uppercased
@@ -358,7 +388,7 @@ class BigIntStringInitTests: XCTestCase {
         let result = self.create(string: input.uppercased(), radix: radix)
         let heap = BigIntPrototype(isNegative: false, words: words)
         let expected = heap.create()
-        XCTAssertEqual(result, expected, input, file: file, line: line)
+        #expect(result == expected, Comment(rawValue: input))
       }
 
       // '+' sign
@@ -366,7 +396,7 @@ class BigIntStringInitTests: XCTestCase {
         let result = self.create(string: "+" + input, radix: radix)
         let heap = BigIntPrototype(isNegative: false, words: words)
         let expected = heap.create()
-        XCTAssertEqual(result, expected, input, file: file, line: line)
+        #expect(result == expected, Comment(rawValue: input))
       }
 
       // '-' sign
@@ -375,7 +405,7 @@ class BigIntStringInitTests: XCTestCase {
         let result = self.create(string: "-" + input, radix: radix)
         let heap = BigIntPrototype(isNegative: true, words: words)
         let expected = heap.create()
-        XCTAssertEqual(result, expected, input, file: file, line: line)
+        #expect(result == expected, Comment(rawValue: input))
       }
     }
   }

--- a/Tests/BigIntTests/WordTests.swift
+++ b/Tests/BigIntTests/WordTests.swift
@@ -79,8 +79,7 @@ struct WordTests {
         func test<Word: FixedWidthInteger, Unit: FixedWidthInteger>
             (direction: Direction = .both,
              words: [Word], of wtype: Word.Type = Word.self,
-             units: [Unit], of utype: Unit.Type = Unit.self,
-             file: StaticString = #file, line: UInt = #line) {
+             units: [Unit], of utype: Unit.Type = Unit.self) {
             switch direction {
             case .wordsToUnits, .both:
                 let actualUnits = [Unit](Units(of: Unit.self, words))

--- a/Tests/BigIntTests/WordTests.swift
+++ b/Tests/BigIntTests/WordTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Károly Lőrentey. All rights reserved.
 //
 
-import XCTest
+import Testing
 @testable import BigInt
 
 // TODO: Return to `where Word.Magnitude == Word` when SR-13491 is resolved
@@ -19,7 +19,7 @@ struct TestDivision<Word: FixedWidthInteger> {
         if o { ph += Word(1) }
 
         if mod >= v {
-            XCTFail("For u = \(u), v = \(v): u mod v = \(mod), which is greater than v")
+            Issue.record("For u = \(u), v = \(v): u mod v = \(mod), which is greater than v")
         }
 
         func message() -> String {
@@ -32,8 +32,8 @@ struct TestDivision<Word: FixedWidthInteger> {
             let pls = String(pl, radix: 16)
             return "(\(uhs),\(uls)) / \(vs) = (\(divs), \(mods)), but div * v + mod = (\(phs),\(pls))"
         }
-        XCTAssertEqual(ph, u.high, message())
-        XCTAssertEqual(pl, u.low, message())
+        #expect(ph == u.high, Comment(rawValue: message()))
+        #expect(pl == u.low, Comment(rawValue: message()))
     }
 
     static func test() {
@@ -47,8 +47,10 @@ struct TestDivision<Word: FixedWidthInteger> {
     }
 }
 
-class WordTests: XCTestCase {
-    func testFullDivide() {
+@Suite
+struct WordTests {
+    @Test
+    func fullDivide() {
         TestDivision<UInt8>.test()
         TestDivision<UInt16>.test()
         TestDivision<UInt32>.test()
@@ -67,7 +69,8 @@ class WordTests: XCTestCase {
         #endif
     }
     
-    func testConversion() {
+    @Test
+    func conversion() {
         enum Direction {
             case unitsToWords
             case wordsToUnits
@@ -81,7 +84,7 @@ class WordTests: XCTestCase {
             switch direction {
             case .wordsToUnits, .both:
                 let actualUnits = [Unit](Units(of: Unit.self, words))
-                XCTAssertEqual(actualUnits, units, "words -> units", file: file, line: line)
+                #expect(actualUnits == units, "words -> units")
             default:
                 break
             }
@@ -89,7 +92,7 @@ class WordTests: XCTestCase {
             case .unitsToWords, .both:
                 var it = units.makeIterator()
                 let actualWords = [Word](count: units.count, generator: { () -> Unit? in it.next() })
-                XCTAssertEqual(actualWords, words, "units -> words", file: file, line: line)
+                #expect(actualWords == words, "units -> words")
             default:
                 break
             }


### PR DESCRIPTION
Migrate all tests from XCTest to Swift Testing framework

- Converted all 15 test files across 4 groups from XCTest to Swift Testing
- Replaced XCTestCase classes with @Suite structs
- Replaced XCTAssertEqual/XCTAssertNil/XCTAssertFalse with #expect
- Replaced XCTAssertThrowsError with do/catch/Issue.record pattern
- Reverted ProfileTests.swift to XCTest (uses XCTest-specific measure APIs under #if Profile)
- Fixed pre-existing test failures: bitWidth check, capacity assertions
